### PR TITLE
Updating dependency versions to stay current (July 2017)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.0.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -95,7 +95,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.6.2</version>
                 <configuration>
                     <source>${source.version}</source>
                     <target>${source.version}</target>
@@ -322,7 +322,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.3</version>
+                <version>2.4</version>
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -380,7 +380,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.7.22</version>
+            <version>2.8.47</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/chabala/brick/controllab/KeepAliveMonitorTest.java
+++ b/src/test/java/org/chabala/brick/controllab/KeepAliveMonitorTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.*;
  */
 public class KeepAliveMonitorTest {
 
-    private final Duration keepAliveDuration = Duration.ofMillis(300);
+    private final Duration keepAliveDuration = Duration.ofMillis(500);
     private final Duration nineTenthsDuration = keepAliveDuration.multipliedBy(9).dividedBy(10);
     private final long keepAliveDurationMs = keepAliveDuration.toMillis();
 


### PR DESCRIPTION
* also increased time duration in a test to avoid spurious Mockito failures. Example:

```
[ERROR] Failures: 
[ERROR]   KeepAliveMonitorTest.testMonitorSendsKeepAlives:52 
Wanted but not invoked:
serialPort.write(<any byte>);
-> at org.chabala.brick.controllab.KeepAliveMonitorTest.testMonitorSendsKeepAlives(KeepAliveMonitorTest.java:52)

However, there were exactly 2 interactions with this mock:
serialPort.getPortName();
-> at org.chabala.brick.controllab.KeepAliveMonitor.<init>(KeepAliveMonitor.java:58)

serialPort.isOpen();
-> at org.chabala.brick.controllab.KeepAliveMonitor.lambda$scheduleTask$0(KeepAliveMonitor.java:75)
```