### PR TITLE
Updating dependency versions to stay current (June 2018)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@ Library for controlling the [LEGO® control lab interface][1].
 [![Build Status][2]][3]
 [![Coverage Status][7]][8]
 [![Codacy Badge][5]][6]
-[![License: GNU LGPL 3.0][4]](http://www.gnu.org/licenses/lgpl-3.0.en.html)
+[![License: GNU LGPL 3.0][4]](https://www.gnu.org/licenses/lgpl-3.0.en.html)
 
 [![Maven Central][16]][17]
-[![Dependency Status][12]][13]
 
 ### What is the control lab?
 
@@ -66,27 +65,25 @@ Some good examples of usage can be found in the
 Run ```mvn clean verify``` to clean, compile, test, and produce the artifact.
 
 ### Licensing
-Licensed under [GNU Lesser General Public License 3.0](http://www.gnu.org/licenses/lgpl-3.0.en.html)
+Licensed under [GNU Lesser General Public License 3.0](https://www.gnu.org/licenses/lgpl-3.0.en.html)
 
 ### References
 
 * <http://www.lgauge.com/technic/LEGOInterfaceB/9751.htm>
 * <http://www.blockcad.net/dacta/>
-* <http://web.archive.org/web/20071130212114/http://troyda.eas.muohio.edu/paper2.html>
+* <https://web.archive.org/web/20071130212114/http://troyda.eas.muohio.edu/paper2.html>
 
 [1]: http://www.peeron.com/inv/sets/9751-1
 [2]: https://travis-ci.org/chabala/brick-control-lab.svg?branch=master
 [3]: https://travis-ci.org/chabala/brick-control-lab
-[4]: http://img.shields.io/badge/license-GNU_LGPL_3.0-brightgreen.svg
+[4]: https://img.shields.io/badge/license-GNU_LGPL_3.0-brightgreen.svg
 [5]: https://api.codacy.com/project/badge/Grade/f05f0d18f49a48659b1066884a7fef68
 [6]: https://www.codacy.com/app/chabala/brick-control-lab
 [7]: https://coveralls.io/repos/github/chabala/brick-control-lab/badge.svg?branch=master
 [8]: https://coveralls.io/github/chabala/brick-control-lab?branch=master
-[9]: http://www.bricklink.com/SL/9751-1.jpg
-[10]: http://www.bricklink.com/catalogItemPic.asp?S=9751-1
+[9]: https://www.bricklink.com/SL/9751-1.jpg
+[10]: https://www.bricklink.com/catalogItemPic.asp?S=9751-1
 [11]: https://en.wikipedia.org/wiki/Lego_Mindstorms#RCX
-[12]: https://www.versioneye.com/user/projects/575c4fd77757a0003bd4c053/badge.svg?style=flat
-[13]: https://www.versioneye.com/user/projects/575c4fd77757a0003bd4c053
 [14]: https://en.wikibooks.org/wiki/Serial_Programming/Serial_Java
 [15]: https://github.com/scream3r/java-simple-serial-connector
 [16]: https://maven-badges.herokuapp.com/maven-central/org.chabala.brick/brick-control-lab/badge.svg

--- a/pom.xml
+++ b/pom.xml
@@ -24,11 +24,11 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -36,15 +36,15 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20.1</version>
+                    <version>2.22.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.0.1</version>
                     <configuration>
                         <links>
                             <link>https://docs.oracle.com/javase/8/docs/api/</link>
@@ -57,7 +57,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.17</version>
+                    <version>3.0.0</version>
                     <configuration>
                         <configLocation>src/main/config/checkstyle.xml</configLocation>
                     </configuration>
@@ -80,7 +80,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-pmd-plugin</artifactId>
-                    <version>3.8</version>
+                    <version>3.10.0</version>
                     <configuration>
                         <linkXRef>true</linkXRef>
                     </configuration>
@@ -88,7 +88,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.9</version>
+                    <version>0.8.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -134,7 +134,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.1.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -160,7 +160,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20.1</version>
+                <version>2.22.0</version>
                 <configuration>
                     <skipAfterFailureCount>1</skipAfterFailureCount>
                 </configuration>
@@ -175,14 +175,14 @@
             </plugin>
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.6</version>
+                <version>3.7.1</version>
                 <configuration>
                     <skipDeploy>true</skipDeploy>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-scm-publish-plugin</artifactId>
-                <version>1.1</version>
+                <version>3.0.0</version>
                 <configuration>
                     <content>${project.reporting.outputDirectory}</content>
                     <scmBranch>gh-pages</scmBranch>
@@ -300,7 +300,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.20.1</version>
+                <version>2.22.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -380,7 +380,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.13.0</version>
+            <version>2.19.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Updating project and plugin dependencies to current versions.
* also removed VersionEye badge from README and updated links to the HTTPS versions, where available.