### PR TITLE
Improvements for maven site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: java
+dist: xenial
 sudo: false
 cache:
   directories:
     - $HOME/.m2
 jdk:
-  - oraclejdk8
+  - openjdk8
 script: mvn clean verify
 after_success:
   - mvn jacoco:report coveralls:report

--- a/README.md
+++ b/README.md
@@ -89,5 +89,11 @@ Licensed under [GNU Lesser General Public License 3.0](https://www.gnu.org/licen
 [16]: https://maven-badges.herokuapp.com/maven-central/org.chabala.brick/brick-control-lab/badge.svg
 [17]: https://maven-badges.herokuapp.com/maven-central/org.chabala.brick/brick-control-lab
 
+<!---
+Potential replacements for maven-badges.herokuapp.com
+[16]: https://img.shields.io/maven-central/v/org.chabala.brick/brick-control-lab.svg
+[17]: https://mvnrepository.com/artifact/org.chabala.brick/brick-control-lab
+-->
+
 LEGO®, DACTA®, TECHNIC®, and MINDSTORMS® are trademarks and/or copyrights of the LEGO Group,
 which does not sponsor, authorize or endorse this software.

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <source.version>1.8</source.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <ghPagesUrl>https://chabala.github.io/${project.artifactId}/</ghPagesUrl>
     </properties>
 
     <build>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -21,17 +21,16 @@
 -->
 <project xmlns="http://maven.apache.org/DECORATION/1.8.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd"
-         name="brick-control-lab">
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd">
     <bannerLeft>
-        <name>brick-control-lab</name>
+        <name>${project.artifactId}</name>
     </bannerLeft>
     <googleAnalyticsAccountId>UA-256611-4</googleAnalyticsAccountId>
     <publishDate />
     <version />
     <body>
         <links>
-            <item name="brick-control-lab" href="./" />
+            <item name="${project.artifactId}" href="${ghPagesUrl}" />
         </links>
         <menu ref="parent" />
         <menu ref="reports" />

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2016 Greg Chabala
+
+    This file is part of brick-control-lab.
+
+    brick-control-lab is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    brick-control-lab is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with brick-control-lab.  If not, see http://www.gnu.org/licenses/.
+
+-->
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd"
+         name="brick-control-lab">
+    <bannerLeft>
+        <name>brick-control-lab</name>
+    </bannerLeft>
+    <googleAnalyticsAccountId>UA-256611-4</googleAnalyticsAccountId>
+    <publishDate />
+    <version />
+    <body>
+        <links>
+            <item name="brick-control-lab" href="./" />
+        </links>
+        <menu ref="parent" />
+        <menu ref="reports" />
+    </body>
+</project>


### PR DESCRIPTION
Adding baseline site descriptor as generated by site:effective-site.
* added Google Analytics ID

Provides a path to adding more documentation pages to the maven site as well as configuring skins.