### PR TITLE
Fluent API for inputs, outputs, and stop button

### DIFF
--- a/src/main/config/checkstyle.xml
+++ b/src/main/config/checkstyle.xml
@@ -111,7 +111,7 @@
         <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
         <module name="RedundantImport"/>
         <module name="UnusedImports">
-            <property name="processJavadoc" value="false"/>
+            <property name="processJavadoc" value="true"/>
         </module>
 
         <!-- Checks for Size Violations.                    -->
@@ -168,7 +168,7 @@
 
         <!-- Checks for class design                         -->
         <!-- See http://checkstyle.sf.net/config_design.html -->
-        <module name="DesignForExtension"/>
+        <!--<module name="DesignForExtension"/>-->
         <module name="FinalClass"/>
         <module name="HideUtilityClassConstructor"/>
         <module name="InterfaceIsType"/>

--- a/src/main/java/org/chabala/brick/controllab/BinaryStringFormatter.java
+++ b/src/main/java/org/chabala/brick/controllab/BinaryStringFormatter.java
@@ -39,8 +39,8 @@ public final class BinaryStringFormatter {
      * @param data a single byte of data
      * @return an eight character string of zeros and ones
      */
-    public static String printByteInBinary(int data) {
-        return Integer.toBinaryString((data & 0xFF) + 0x100).substring(1);
+    public static String printByteInBinary(byte data) {
+        return Integer.toBinaryString(Byte.toUnsignedInt(data) + 0x100).substring(1);
     }
 
     private BinaryStringFormatter() {

--- a/src/main/java/org/chabala/brick/controllab/ByteConsumer.java
+++ b/src/main/java/org/chabala/brick/controllab/ByteConsumer.java
@@ -18,37 +18,16 @@
  */
 package org.chabala.brick.controllab;
 
-import java.util.EventObject;
-
 /**
- * The event triggered by interacting with the red stop button on the control
- * lab.
+ * Like {@link java.util.function.IntConsumer}, but for {@link Byte}s.
  */
-public class StopButtonEvent extends EventObject {
-
-    private final byte rawValue;
+@FunctionalInterface
+public interface ByteConsumer {
 
     /**
-     * Constructs a StopButtonEvent.
+     * Performs this operation on the given argument.
      *
-     * @param source The object on which the Event initially occurred.
-     * @param rawValue The raw data that signaled this event.
-     * @throws IllegalArgumentException if source is null.
+     * @param value the input argument
      */
-    public StopButtonEvent(Object source, byte rawValue) {
-        super(source);
-        this.rawValue = rawValue;
-    }
-
-    public byte getRawValue() {
-        return rawValue;
-    }
-
-    @Override
-    public String toString() {
-        return "StopButtonEvent{" +
-                "source=" + source +
-                ", rawValue=" + String.format("0x%02X ", rawValue) +
-                '}';
-    }
+    void accept(byte value);
 }

--- a/src/main/java/org/chabala/brick/controllab/ControlLab.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLab.java
@@ -41,7 +41,7 @@ import java.util.Set;
  *   }
  *       }</pre>
  */
-public interface ControlLab extends Closeable, MutatesInputListeners {
+public interface ControlLab extends Closeable {
 
     /**
      * Returns a new ControlLab instance.
@@ -110,6 +110,13 @@ public interface ControlLab extends Closeable, MutatesInputListeners {
      * @return handle for the stop button on this control lab instance
      */
     StopButton getStopButton();
+
+    /**
+     * Return a handle for the input specified on this control lab instance.
+     * @param inputId identifier of the desired input port
+     * @return handle for the input specific to this control lab instance
+     */
+    Input getInput(InputId inputId);
 
     /**
      * Disconnects from the control lab and releases any resources.

--- a/src/main/java/org/chabala/brick/controllab/ControlLab.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLab.java
@@ -67,6 +67,13 @@ public interface ControlLab extends Closeable {
     void open(String portName) throws IOException;
 
     /**
+     * Returns the system specific serial port identifier the control lab is
+     * connected to, or empty string if not connected.
+     * @return system specific serial port identifier or empty string
+     */
+    String getConnectedPortName();
+
+    /**
      * Stops sending power to the specified outputs.
      * @param outputs outputs to stop
      * @throws IOException if any number of possible communication issues occurs

--- a/src/main/java/org/chabala/brick/controllab/ControlLab.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLab.java
@@ -18,8 +18,11 @@
  */
 package org.chabala.brick.controllab;
 
+import org.slf4j.LoggerFactory;
+
 import java.io.Closeable;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Set;
 
@@ -48,7 +51,8 @@ public interface ControlLab extends Closeable {
      * @return a new ControlLab instance
      */
     static ControlLab newControlLab() {
-        return new ControlLabImpl();
+        return new ControlLabImpl(
+                LoggerFactory.getLogger(MethodHandles.lookup().lookupClass()));
     }
 
     /**

--- a/src/main/java/org/chabala/brick/controllab/ControlLab.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLab.java
@@ -99,6 +99,13 @@ public interface ControlLab extends Closeable, MutatesInputListeners {
     void setOutputPowerLevel(PowerLevel powerLevel, Set<OutputId> outputs) throws IOException;
 
     /**
+     * Return a handle for the output specified on this control lab instance.
+     * @param outputId identifier of the desired output port
+     * @return handle for the output specific to this control lab instance
+     */
+    Output getOutput(OutputId outputId);
+
+    /**
      * Disconnects from the control lab and releases any resources.
      * @throws IOException if any number of possible communication issues occurs
      */

--- a/src/main/java/org/chabala/brick/controllab/ControlLab.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLab.java
@@ -106,6 +106,13 @@ public interface ControlLab extends Closeable {
     Output getOutput(OutputId outputId);
 
     /**
+     * Return a handle for multiple outputs on this control lab instance.
+     * @param outputs identifiers of the desired output ports
+     * @return handle for the outputs specific to this control lab instance
+     */
+    Output getOutputGroup(Set<OutputId> outputs);
+
+    /**
      * Return a handle for the stop button on this control lab instance.
      * @return handle for the stop button on this control lab instance
      */

--- a/src/main/java/org/chabala/brick/controllab/ControlLab.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLab.java
@@ -71,14 +71,14 @@ public interface ControlLab extends Closeable, MutatesInputListeners {
      * @param outputs outputs to stop
      * @throws IOException if any number of possible communication issues occurs
      */
-    void turnOutputOff(Set<Output> outputs) throws IOException;
+    void turnOutputOff(Set<OutputId> outputs) throws IOException;
 
     /**
      * Starts sending power to the specified outputs.
      * @param outputs outputs to start
      * @throws IOException if any number of possible communication issues occurs
      */
-    void turnOutputOn(Set<Output> outputs) throws IOException;
+    void turnOutputOn(Set<OutputId> outputs) throws IOException;
 
     /**
      * Sets the {@link Direction} of the specified outputs. Direction may be changed
@@ -87,7 +87,7 @@ public interface ControlLab extends Closeable, MutatesInputListeners {
      * @param outputs which outputs to change
      * @throws IOException if any number of possible communication issues occurs
      */
-    void setOutputDirection(Direction direction, Set<Output> outputs) throws IOException;
+    void setOutputDirection(Direction direction, Set<OutputId> outputs) throws IOException;
 
     /**
      * Sets the {@link PowerLevel} of the specified outputs. Power level may be changed
@@ -96,7 +96,7 @@ public interface ControlLab extends Closeable, MutatesInputListeners {
      * @param outputs which outputs to change
      * @throws IOException if any number of possible communication issues occurs
      */
-    void setOutputPowerLevel(PowerLevel powerLevel, Set<Output> outputs) throws IOException;
+    void setOutputPowerLevel(PowerLevel powerLevel, Set<OutputId> outputs) throws IOException;
 
     /**
      * Disconnects from the control lab and releases any resources.

--- a/src/main/java/org/chabala/brick/controllab/ControlLab.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLab.java
@@ -106,6 +106,12 @@ public interface ControlLab extends Closeable, MutatesInputListeners {
     Output getOutput(OutputId outputId);
 
     /**
+     * Return a handle for the stop button on this control lab instance.
+     * @return handle for the stop button on this control lab instance
+     */
+    StopButton getStopButton();
+
+    /**
      * Disconnects from the control lab and releases any resources.
      * @throws IOException if any number of possible communication issues occurs
      */

--- a/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
@@ -150,13 +150,13 @@ class ControlLabImpl implements ControlLab {
 
     /** {@inheritDoc} */
     @Override
-    public void addSensorListener(Input input, SensorListener listener) {
+    public void addSensorListener(InputId input, SensorListener listener) {
         inputManager.addSensorListener(input, listener);
     }
 
     /** {@inheritDoc} */
     @Override
-    public void removeSensorListener(Input input, SensorListener listener) {
+    public void removeSensorListener(InputId input, SensorListener listener) {
         inputManager.removeSensorListener(input, listener);
     }
 

--- a/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
@@ -43,6 +43,7 @@ class ControlLabImpl implements ControlLab {
     private final InputManager inputManager;
     private final BiFunction<SerialPort, InputManager, SerialPortEventListener> listenerFactory;
     private final Map<OutputId, Output> outputMap;
+    private final StopButton stopButton;
 
     /**
      * Default constructor using jSSC serial implementation.
@@ -60,6 +61,7 @@ class ControlLabImpl implements ControlLab {
         outputMap = Collections.unmodifiableMap(new EnumMap<>(
                 Arrays.stream(OutputId.values()).collect(
                         Collectors.toMap(Function.identity(), id -> new Output(this, id)))));
+        stopButton = new StopButton(inputManager);
     }
 
     @Override
@@ -136,20 +138,14 @@ class ControlLabImpl implements ControlLab {
 
     /** {@inheritDoc} */
     @Override
+    public StopButton getStopButton() {
+        return stopButton;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public List<String> getAvailablePorts() {
         return portFactory.getAvailablePorts();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void addStopButtonListener(StopButtonListener listener) {
-        inputManager.addStopButtonListener(listener);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void removeStopButtonListener(StopButtonListener listener) {
-        inputManager.removeStopButtonListener(listener);
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
@@ -101,26 +101,26 @@ class ControlLabImpl implements ControlLab {
 
     /** {@inheritDoc} */
     @Override
-    public void turnOutputOff(Set<Output> outputs) throws IOException {
-        sendCommand(Protocol.OUTPUT_OFF, Output.encodeSetToByte(outputs));
+    public void turnOutputOff(Set<OutputId> outputs) throws IOException {
+        sendCommand(Protocol.OUTPUT_OFF, OutputId.encodeSetToByte(outputs));
     }
 
     /** {@inheritDoc} */
     @Override
-    public void turnOutputOn(Set<Output> outputs) throws IOException {
-        sendCommand(Protocol.OUTPUT_ON, Output.encodeSetToByte(outputs));
+    public void turnOutputOn(Set<OutputId> outputs) throws IOException {
+        sendCommand(Protocol.OUTPUT_ON, OutputId.encodeSetToByte(outputs));
     }
 
     /** {@inheritDoc} */
     @Override
-    public void setOutputDirection(Direction direction, Set<Output> outputs) throws IOException {
-        sendCommand(direction.getCode(), Output.encodeSetToByte(outputs));
+    public void setOutputDirection(Direction direction, Set<OutputId> outputs) throws IOException {
+        sendCommand(direction.getCode(), OutputId.encodeSetToByte(outputs));
     }
 
     /** {@inheritDoc} */
     @Override
-    public void setOutputPowerLevel(PowerLevel powerLevel, Set<Output> outputs) throws IOException {
-        sendCommand(powerLevel.getCode(), Output.encodeSetToByte(outputs));
+    public void setOutputPowerLevel(PowerLevel powerLevel, Set<OutputId> outputs) throws IOException {
+        sendCommand(powerLevel.getCode(), OutputId.encodeSetToByte(outputs));
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
@@ -18,7 +18,6 @@
  */
 package org.chabala.brick.controllab;
 
-import org.chabala.brick.controllab.sensor.SensorListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +43,7 @@ class ControlLabImpl implements ControlLab {
     private final BiFunction<SerialPort, InputManager, SerialPortEventListener> listenerFactory;
     private final Map<OutputId, Output> outputMap;
     private final StopButton stopButton;
+    private final Map<InputId, Input> inputMap;
 
     /**
      * Default constructor using jSSC serial implementation.
@@ -62,6 +62,9 @@ class ControlLabImpl implements ControlLab {
                 Arrays.stream(OutputId.values()).collect(
                         Collectors.toMap(Function.identity(), id -> new Output(this, id)))));
         stopButton = new StopButton(inputManager);
+        inputMap = Collections.unmodifiableMap(new EnumMap<>(
+                Arrays.stream(InputId.values()).collect(
+                        Collectors.toMap(Function.identity(), id -> new Input(inputManager, id)))));
     }
 
     @Override
@@ -144,20 +147,14 @@ class ControlLabImpl implements ControlLab {
 
     /** {@inheritDoc} */
     @Override
+    public Input getInput(InputId inputId) {
+        return inputMap.get(inputId);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public List<String> getAvailablePorts() {
         return portFactory.getAvailablePorts();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void addSensorListener(InputId input, SensorListener listener) {
-        inputManager.addSensorListener(input, listener);
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public void removeSensorListener(InputId input, SensorListener listener) {
-        inputManager.removeSensorListener(input, listener);
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
@@ -115,6 +115,12 @@ class ControlLabImpl implements ControlLab {
 
     /** {@inheritDoc} */
     @Override
+    public Output getOutputGroup(Set<OutputId> outputs) {
+        return new Output(this, outputs);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public StopButton getStopButton() {
         return stopButton;
     }

--- a/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
@@ -23,11 +23,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
@@ -41,6 +42,7 @@ class ControlLabImpl implements ControlLab {
     private KeepAliveMonitor keepAliveMonitor;
     private final InputManager inputManager;
     private final BiFunction<SerialPort, InputManager, SerialPortEventListener> listenerFactory;
+    private final Map<OutputId, Output> outputMap;
 
     /**
      * Default constructor using jSSC serial implementation.
@@ -55,6 +57,9 @@ class ControlLabImpl implements ControlLab {
         this.portFactory = portFactory;
         this.inputManager = inputManager;
         this.listenerFactory = listenerFactory;
+        outputMap = Collections.unmodifiableMap(new EnumMap<>(
+                Arrays.stream(OutputId.values()).collect(
+                        Collectors.toMap(Function.identity(), id -> new Output(this, id)))));
     }
 
     @Override
@@ -121,6 +126,12 @@ class ControlLabImpl implements ControlLab {
     @Override
     public void setOutputPowerLevel(PowerLevel powerLevel, Set<OutputId> outputs) throws IOException {
         sendCommand(powerLevel.getCode(), OutputId.encodeSetToByte(outputs));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Output getOutput(OutputId outputId) {
+        return outputMap.get(outputId);
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
@@ -23,8 +23,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.LockSupport;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -75,7 +73,6 @@ class ControlLabImpl implements ControlLab {
 
         serialPortWriter = new SerialPortWriter(serialPort, log);
         serialPortWriter.sendCommand(Protocol.HANDSHAKE_CHALLENGE.getBytes());
-        LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(1));
         if (!serialListener.isHandshakeSeen()) {
             close();
             throw new IOException("No response to handshake");
@@ -116,6 +113,9 @@ class ControlLabImpl implements ControlLab {
     /** {@inheritDoc} */
     @Override
     public Output getOutputGroup(Set<OutputId> outputs) {
+        if (outputs.size() == 1) {
+            return getOutput(outputs.iterator().next());
+        }
         return new Output(this, outputs);
     }
 

--- a/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
@@ -19,7 +19,6 @@
 package org.chabala.brick.controllab;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
@@ -31,7 +30,7 @@ import java.util.stream.Collectors;
  * Object to represent interacting with the LEGO® control lab interface.
  */
 class ControlLabImpl implements ControlLab {
-    private final Logger log = LoggerFactory.getLogger(ControlLab.class);
+    private final Logger log;
     private final SerialPortFactory portFactory;
     private SerialPort serialPort;
     private final InputManager inputManager;
@@ -44,13 +43,15 @@ class ControlLabImpl implements ControlLab {
     /**
      * Default constructor using jSSC serial implementation.
      */
-    ControlLabImpl() {
-        this(new JsscSerialPortFactory(), new InputManager(), SerialListener::new);
+    ControlLabImpl(Logger log) {
+        this(log, new JsscSerialPortFactory(), new InputManager(), SerialListener::new);
     }
 
-    ControlLabImpl(SerialPortFactory portFactory,
+    ControlLabImpl(Logger log,
+                   SerialPortFactory portFactory,
                    InputManager inputManager,
                    BiFunction<SerialPort, InputManager, SerialPortEventListener> listenerFactory) {
+        this.log = log;
         this.portFactory = portFactory;
         this.inputManager = inputManager;
         this.listenerFactory = listenerFactory;
@@ -150,14 +151,16 @@ class ControlLabImpl implements ControlLab {
     /** {@inheritDoc} */
     @Override
     public void close() throws IOException {
-        if (serialPort != null) {
-            serialPortWriter.sendCommand(Protocol.DISCONNECT);
-            serialPort.close();
-            serialPort = null;
-        }
         if (serialPortWriter != null) {
+            if (serialPort != null) {
+                serialPortWriter.sendCommand(Protocol.DISCONNECT);
+            }
             serialPortWriter.close();
             serialPortWriter = null;
+        }
+        if (serialPort != null) {
+            serialPort.close();
+            serialPort = null;
         }
     }
 

--- a/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
+++ b/src/main/java/org/chabala/brick/controllab/ControlLabImpl.java
@@ -139,6 +139,16 @@ class ControlLabImpl implements ControlLab {
 
     /** {@inheritDoc} */
     @Override
+    public String getConnectedPortName() {
+        if (serialPort != null) {
+            return serialPort.getPortName();
+        } else {
+            return "";
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void close() throws IOException {
         if (serialPort != null) {
             serialPortWriter.sendCommand(Protocol.DISCONNECT);
@@ -149,5 +159,13 @@ class ControlLabImpl implements ControlLab {
             serialPortWriter.close();
             serialPortWriter = null;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "ControlLabImpl{" +
+                "serialPort=" + serialPort +
+                "}@" +
+                System.identityHashCode(this);
     }
 }

--- a/src/main/java/org/chabala/brick/controllab/Input.java
+++ b/src/main/java/org/chabala/brick/controllab/Input.java
@@ -22,24 +22,33 @@ import org.chabala.brick.controllab.sensor.SensorEvent;
 import org.chabala.brick.controllab.sensor.SensorListener;
 
 /**
- * Implementors of this interface can add or remove listeners for input events.
+ * Handle for an input port on a specific control lab instance. Obtain via {@link ControlLab#getInput(InputId)}.
  */
-public interface MutatesInputListeners {
+public class Input {
+    private final InputManager inputManager;
+    private final InputId inputId;
+
+    Input(InputManager inputManager, InputId inputId) {
+        this.inputManager = inputManager;
+        this.inputId = inputId;
+    }
 
     /**
      * Attach a listener for {@link SensorEvent}s.
      *
      * <p>Multiple listeners are allowed. A listener instance will only be registered
      * once even if it is added multiple times.
-     * @param input    input to add the listener to
      * @param listener listener to add
      */
-    void addSensorListener(InputId input, SensorListener listener);
+    public void addListener(SensorListener listener) {
+        inputManager.addSensorListener(inputId, listener);
+    }
 
     /**
      * Remove a listener for {@link SensorEvent}s.
-     * @param input    input to remove the listener from
      * @param listener listener to remove
      */
-    void removeSensorListener(InputId input, SensorListener listener);
+    public void removeListener(SensorListener listener) {
+        inputManager.removeSensorListener(inputId, listener);
+    }
 }

--- a/src/main/java/org/chabala/brick/controllab/Input.java
+++ b/src/main/java/org/chabala/brick/controllab/Input.java
@@ -22,7 +22,8 @@ import org.chabala.brick.controllab.sensor.SensorEvent;
 import org.chabala.brick.controllab.sensor.SensorListener;
 
 /**
- * Handle for an input port on a specific control lab instance. Obtain via {@link ControlLab#getInput(InputId)}.
+ * Handle for an input port on a specific control lab instance. Obtain
+ * via {@link ControlLab#getInput(InputId)}.
  */
 public class Input {
     private final InputManager inputManager;
@@ -50,5 +51,13 @@ public class Input {
      */
     public void removeListener(SensorListener listener) {
         inputManager.removeSensorListener(inputId, listener);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return "Input{" +
+                "inputId=" + inputId +
+                '}';
     }
 }

--- a/src/main/java/org/chabala/brick/controllab/InputId.java
+++ b/src/main/java/org/chabala/brick/controllab/InputId.java
@@ -27,7 +27,7 @@ package org.chabala.brick.controllab;
  * Inputs 5-8 are active, they supply power to the connected sensor
  * in order for it to work. They are colored blue on the control lab.
  */
-public enum Input {
+public enum InputId {
     /** Input 1. */ I1(InputType.PASSIVE),
     /** Input 2. */ I2(InputType.PASSIVE),
     /** Input 3. */ I3(InputType.PASSIVE),
@@ -39,7 +39,7 @@ public enum Input {
 
     private final InputType inputType;
 
-    Input(InputType inputType) {
+    InputId(InputType inputType) {
         this.inputType = inputType;
     }
 

--- a/src/main/java/org/chabala/brick/controllab/InputId.java
+++ b/src/main/java/org/chabala/brick/controllab/InputId.java
@@ -43,6 +43,11 @@ public enum InputId {
         this.inputType = inputType;
     }
 
+    /**
+     * Returns an {@link InputType} to indicate if this {@link InputId} is
+     * active or passive.
+     * @return the input type for this input ID
+     */
     public InputType getInputType() {
         return inputType;
     }

--- a/src/main/java/org/chabala/brick/controllab/InputManager.java
+++ b/src/main/java/org/chabala/brick/controllab/InputManager.java
@@ -97,7 +97,7 @@ class InputManager implements MutatesInputListeners {
         if (0x00 != inputFrame[lastCommandIndex]) {
             //TODO: make event listener for output feedback
             log.info("Ports affected by last command {}",
-                    Output.decodeByteToSet(inputFrame[lastCommandIndex]));
+                    OutputId.decodeByteToSet(inputFrame[lastCommandIndex]));
         }
         for (Input in : frameInputOrder) {
             setSensorValue(in, inputFrame[frameIndex++], inputFrame[frameIndex++]);

--- a/src/main/java/org/chabala/brick/controllab/InputManager.java
+++ b/src/main/java/org/chabala/brick/controllab/InputManager.java
@@ -34,16 +34,17 @@ import java.util.*;
 class InputManager implements MutatesInputListeners {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
-    private final Map<Input, byte[]> sensorData;
-    private final Map<Input, Set<SensorListener>> sensorListeners;
-    private final List<Input> frameInputOrder =
-            Arrays.asList(Input.I4, Input.I8, Input.I3, Input.I7, Input.I2, Input.I6, Input.I1, Input.I5);
+    private final Map<InputId, byte[]> sensorData;
+    private final Map<InputId, Set<SensorListener>> sensorListeners;
+    private final List<InputId> frameInputOrder =
+            Arrays.asList(InputId.I4, InputId.I8, InputId.I3, InputId.I7,
+                          InputId.I2, InputId.I6, InputId.I1, InputId.I5);
     private ByteConsumer processStopButton = null;
 
     InputManager() {
-        sensorData = Collections.synchronizedMap(new EnumMap<>(Input.class));
-        sensorListeners = Collections.synchronizedMap(new EnumMap<>(Input.class));
-        Arrays.stream(Input.values()).forEach(i -> {
+        sensorData = Collections.synchronizedMap(new EnumMap<>(InputId.class));
+        sensorListeners = Collections.synchronizedMap(new EnumMap<>(InputId.class));
+        Arrays.stream(InputId.values()).forEach(i -> {
             sensorData.put(i, new byte[] {0, 0});
             sensorListeners.put(i, Collections.synchronizedSet(new HashSet<>(2)));
         });
@@ -51,13 +52,13 @@ class InputManager implements MutatesInputListeners {
 
     /** {@inheritDoc} */
     @Override
-    public void addSensorListener(Input input, SensorListener listener) {
+    public void addSensorListener(InputId input, SensorListener listener) {
         sensorListeners.get(input).add(listener);
     }
 
     /** {@inheritDoc} */
     @Override
-    public void removeSensorListener(Input input, SensorListener listener) {
+    public void removeSensorListener(InputId input, SensorListener listener) {
         sensorListeners.get(input).remove(listener);
     }
 
@@ -85,7 +86,7 @@ class InputManager implements MutatesInputListeners {
             log.info("Ports affected by last command {}",
                     OutputId.decodeByteToSet(inputFrame[lastCommandIndex]));
         }
-        for (Input in : frameInputOrder) {
+        for (InputId in : frameInputOrder) {
             setSensorValue(in, inputFrame[frameIndex++], inputFrame[frameIndex++]);
         }
     }
@@ -104,7 +105,7 @@ class InputManager implements MutatesInputListeners {
         }
     }
 
-    private void setSensorValue(Input input, byte high, byte low) {
+    private void setSensorValue(InputId input, byte high, byte low) {
         byte[] newValue = {high, low};
         byte[] oldValue = sensorData.put(input, newValue);
         if (!Arrays.equals(newValue, oldValue)) {

--- a/src/main/java/org/chabala/brick/controllab/InputManager.java
+++ b/src/main/java/org/chabala/brick/controllab/InputManager.java
@@ -31,7 +31,7 @@ import java.util.*;
  * Manages registration of input event listeners, and parsing input
  * data into events for those listeners.
  */
-class InputManager implements MutatesInputListeners {
+class InputManager {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
     private final Map<InputId, byte[]> sensorData;
@@ -50,15 +50,24 @@ class InputManager implements MutatesInputListeners {
         });
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public void addSensorListener(InputId input, SensorListener listener) {
+    /**
+     * Attach a listener for {@link SensorEvent}s.
+     *
+     * <p>Multiple listeners are allowed. A listener instance will only be registered
+     * once even if it is added multiple times.
+     * @param input    input to add the listener to
+     * @param listener listener to add
+     */
+    void addSensorListener(InputId input, SensorListener listener) {
         sensorListeners.get(input).add(listener);
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public void removeSensorListener(InputId input, SensorListener listener) {
+    /**
+     * Remove a listener for {@link SensorEvent}s.
+     * @param input    input to remove the listener from
+     * @param listener listener to remove
+     */
+    void removeSensorListener(InputId input, SensorListener listener) {
         sensorListeners.get(input).remove(listener);
     }
 

--- a/src/main/java/org/chabala/brick/controllab/InputManager.java
+++ b/src/main/java/org/chabala/brick/controllab/InputManager.java
@@ -95,6 +95,7 @@ class InputManager implements MutatesInputListeners {
         processStopButton(inputFrame[frameIndex++]);
         int lastCommandIndex = frameIndex++;
         if (0x00 != inputFrame[lastCommandIndex]) {
+            //TODO: make event listener for output feedback
             log.info("Ports affected by last command {}",
                     Output.decodeByteToSet(inputFrame[lastCommandIndex]));
         }

--- a/src/main/java/org/chabala/brick/controllab/InputManager.java
+++ b/src/main/java/org/chabala/brick/controllab/InputManager.java
@@ -129,15 +129,4 @@ class InputManager {
     void setStopButtonCallback(ByteConsumer processStopButton) {
         this.processStopButton = processStopButton;
     }
-
-    @FunctionalInterface
-    public interface ByteConsumer {
-
-        /**
-         * Performs this operation on the given argument.
-         *
-         * @param value the input argument
-         */
-        void accept(byte value);
-    }
 }

--- a/src/main/java/org/chabala/brick/controllab/JsscSerialPort.java
+++ b/src/main/java/org/chabala/brick/controllab/JsscSerialPort.java
@@ -139,4 +139,13 @@ class JsscSerialPort implements SerialPort {
             throw new IOException(e);
         }
     }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return "JsscSerialPort{" +
+                "portName='" + getPortName() + '\'' +
+                ", open=" + isOpen() +
+                '}';
+    }
 }

--- a/src/main/java/org/chabala/brick/controllab/MutatesInputListeners.java
+++ b/src/main/java/org/chabala/brick/controllab/MutatesInputListeners.java
@@ -34,12 +34,12 @@ public interface MutatesInputListeners {
      * @param input    input to add the listener to
      * @param listener listener to add
      */
-    void addSensorListener(Input input, SensorListener listener);
+    void addSensorListener(InputId input, SensorListener listener);
 
     /**
      * Remove a listener for {@link SensorEvent}s.
      * @param input    input to remove the listener from
      * @param listener listener to remove
      */
-    void removeSensorListener(Input input, SensorListener listener);
+    void removeSensorListener(InputId input, SensorListener listener);
 }

--- a/src/main/java/org/chabala/brick/controllab/MutatesInputListeners.java
+++ b/src/main/java/org/chabala/brick/controllab/MutatesInputListeners.java
@@ -22,7 +22,7 @@ import org.chabala.brick.controllab.sensor.SensorEvent;
 import org.chabala.brick.controllab.sensor.SensorListener;
 
 /**
- * Implementors of this interface can add or remove listeners for input and stop button events.
+ * Implementors of this interface can add or remove listeners for input events.
  */
 public interface MutatesInputListeners {
 
@@ -42,19 +42,4 @@ public interface MutatesInputListeners {
      * @param listener listener to remove
      */
     void removeSensorListener(Input input, SensorListener listener);
-
-    /**
-     * Attach a listener for {@link StopButtonEvent}s.
-     *
-     * <p>Multiple listeners are allowed. A listener instance will only be registered
-     * once even if it is added multiple times.
-     * @param listener listener to add
-     */
-    void addStopButtonListener(StopButtonListener listener);
-
-    /**
-     * Remove a listener for {@link StopButtonEvent}s.
-     * @param listener listener to remove
-     */
-    void removeStopButtonListener(StopButtonListener listener);
 }

--- a/src/main/java/org/chabala/brick/controllab/Output.java
+++ b/src/main/java/org/chabala/brick/controllab/Output.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2016 Greg Chabala
+ *
+ * This file is part of brick-control-lab.
+ *
+ * brick-control-lab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * brick-control-lab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with brick-control-lab.  If not, see http://www.gnu.org/licenses/.
+ */
+package org.chabala.brick.controllab;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Handle for an output port on a specific control lab instance. Obtain via {@link ControlLab#getOutput(OutputId)}.
+ */
+public class Output {
+
+    private final ControlLab controlLab;
+    private final Set<OutputId> outputIdSet;
+
+    Output(ControlLab controlLab, OutputId outputId) {
+        this.controlLab = controlLab;
+        outputIdSet = EnumSet.of(outputId);
+    }
+
+    public Output turnOff() throws IOException {
+        controlLab.turnOutputOff(outputIdSet);
+        return this;
+    }
+
+    public Output turnOn() throws IOException {
+        controlLab.turnOutputOn(outputIdSet);
+        return this;
+    }
+
+    public Output setDirection(Direction direction) throws IOException {
+        controlLab.setOutputDirection(direction, outputIdSet);
+        return this;
+    }
+
+    public Output reverseDirection() throws IOException {
+        return setDirection(Direction.REVERSE);
+    }
+
+    public Output setPowerLevel(PowerLevel powerLevel) throws IOException {
+        controlLab.setOutputPowerLevel(powerLevel, outputIdSet);
+        return this;
+    }
+}

--- a/src/main/java/org/chabala/brick/controllab/Output.java
+++ b/src/main/java/org/chabala/brick/controllab/Output.java
@@ -23,7 +23,8 @@ import java.util.EnumSet;
 import java.util.Set;
 
 /**
- * Handle for an output port on a specific control lab instance. Obtain via {@link ControlLab#getOutput(OutputId)}.
+ * Handle for an output port (or group of ports) on a specific control lab instance.
+ * Obtain via {@link ControlLab#getOutput(OutputId)} or {@link ControlLab#getOutputGroup(Set)}.
  */
 public class Output {
 
@@ -31,8 +32,12 @@ public class Output {
     private final Set<OutputId> outputIdSet;
 
     Output(ControlLab controlLab, OutputId outputId) {
+        this(controlLab, EnumSet.of(outputId));
+    }
+
+    Output(ControlLab controlLab, Set<OutputId> outputIdSet) {
         this.controlLab = controlLab;
-        outputIdSet = EnumSet.of(outputId);
+        this.outputIdSet = outputIdSet;
     }
 
     public Output turnOff() throws IOException {

--- a/src/main/java/org/chabala/brick/controllab/Output.java
+++ b/src/main/java/org/chabala/brick/controllab/Output.java
@@ -19,6 +19,7 @@
 package org.chabala.brick.controllab;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -31,36 +32,98 @@ public class Output {
     private final ControlLab controlLab;
     private final Set<OutputId> outputIdSet;
 
+    /**
+     * Called internally by {@link ControlLab#getOutput(OutputId)}.
+     * @param controlLab the control lab this output is a handle to
+     * @param outputId the output port ID on that control lab
+     */
     Output(ControlLab controlLab, OutputId outputId) {
         this(controlLab, EnumSet.of(outputId));
     }
 
+    /**
+     * Called internally by {@link ControlLab#getOutputGroup(Set)}.
+     * @param controlLab the control lab this output is a handle to
+     * @param outputIdSet the output IDs this output should reference
+     */
     Output(ControlLab controlLab, Set<OutputId> outputIdSet) {
         this.controlLab = controlLab;
         this.outputIdSet = outputIdSet;
     }
 
+    /**
+     * Returns set of {@link OutputId}s this {@link Output} relates to. In normal
+     * usage, this is unlikely to be called as one would obtain the {@link Output}
+     * from {@link ControlLab#getOutput(OutputId)} and immediately chain one of the
+     * fluent method calls. But it can useful to inspect the {@link OutputId}s if the
+     * {@link Output} reference is retained and seperated from the creation site.
+     * @return set of {@link OutputId}s this {@link Output} relates to
+     */
+    public Set<OutputId> getOutputIdSet() {
+        return Collections.unmodifiableSet(outputIdSet);
+    }
+
+    /**
+     * Stops sending power to this output.
+     * @return self reference to the output for chaining
+     * @throws IOException if any number of possible communication issues occurs
+     */
     public Output turnOff() throws IOException {
         controlLab.turnOutputOff(outputIdSet);
         return this;
     }
 
+    /**
+     * Starts sending power to this output.
+     * @return self reference to the output for chaining
+     * @throws IOException if any number of possible communication issues occurs
+     */
     public Output turnOn() throws IOException {
         controlLab.turnOutputOn(outputIdSet);
         return this;
     }
 
+    /**
+     * Sets the {@link Direction} of this output. Direction may be changed
+     * while the output is powered or unpowered.
+     * @param direction desired direction
+     * @return self reference to the output for chaining
+     * @throws IOException if any number of possible communication issues occurs
+     */
     public Output setDirection(Direction direction) throws IOException {
         controlLab.setOutputDirection(direction, outputIdSet);
         return this;
     }
 
+    /**
+     * Reverses the {@link Direction} of this output. This is a convenience method
+     * that is the same as
+     * {@link Output#setDirection(Direction) setDirection(}{@link Direction#REVERSE Direction.REVERSE)}.
+     * @return self reference to the output for chaining
+     * @throws IOException if any number of possible communication issues occurs
+     */
     public Output reverseDirection() throws IOException {
         return setDirection(Direction.REVERSE);
     }
 
+    /**
+     * Sets the {@link PowerLevel} of this output. Power level may be changed
+     * while the output is powered or unpowered.
+     * @param powerLevel desired power level
+     * @return self reference to the output for chaining
+     * @throws IOException if any number of possible communication issues occurs
+     */
     public Output setPowerLevel(PowerLevel powerLevel) throws IOException {
         controlLab.setOutputPowerLevel(powerLevel, outputIdSet);
         return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        return "Output{" +
+                "controlLab=" + controlLab +
+                ", outputIdSet=" + outputIdSet +
+                '}';
     }
 }

--- a/src/main/java/org/chabala/brick/controllab/OutputId.java
+++ b/src/main/java/org/chabala/brick/controllab/OutputId.java
@@ -56,17 +56,19 @@ public enum OutputId {
         return r;
     }
 
+    private static final OutputId[] ENUM_VALUES = values();
+
     /**
      * Decodes a byte into a {@link Set} of {@link OutputId}s.
      * @param b byte where each bit corresponds to the ordinal of an Output
      * @return a Set containing the desired Outputs
      */
     public static Set<OutputId> decodeByteToSet(byte b) {
-        OutputId[] enums = OutputId.class.getEnumConstants();
         Set<OutputId> enumSet = EnumSet.noneOf(OutputId.class);
+        int byteAsInt = Byte.toUnsignedInt(b);
         for (int bit = 0; bit < Byte.SIZE; bit++) {
-            if ((b & 0xFF & 1 << bit) > 0) {
-                enumSet.add(enums[bit]);
+            if ((byteAsInt & 1 << bit) > 0) {
+                enumSet.add(ENUM_VALUES[bit]);
             }
         }
         return enumSet;

--- a/src/main/java/org/chabala/brick/controllab/OutputId.java
+++ b/src/main/java/org/chabala/brick/controllab/OutputId.java
@@ -25,7 +25,7 @@ import java.util.Set;
 /**
  * Identifiers for the output ports on the control lab.
  */
-public enum Output {
+public enum OutputId {
     /** Output A. */ A,
     /** Output B. */ B,
     /** Output C. */ C,
@@ -38,14 +38,14 @@ public enum Output {
     /**
      * Convenience constant for specifying all output ports.
      */
-    public static final Set<Output> ALL = Collections.unmodifiableSet(EnumSet.allOf(Output.class));
+    public static final Set<OutputId> ALL = Collections.unmodifiableSet(EnumSet.allOf(OutputId.class));
 
     /**
      * Encodes values from a {@link Set} of {@link Enum}s to a byte. Uses the
      * ordinal of the Enum as the position of the bit in the byte to set high.
      *
      * @param set set of values to be encoded
-     * @param <T> type of Enum, only used with {@link Output} internally
+     * @param <T> type of Enum, only used with {@link OutputId} internally
      * @return a byte with high bits relating to the values in the set
      */
     public static <T extends Enum<T>> byte encodeSetToByte(Set<T> set) {
@@ -57,13 +57,13 @@ public enum Output {
     }
 
     /**
-     * Decodes a byte into a {@link Set} of {@link Output}s.
+     * Decodes a byte into a {@link Set} of {@link OutputId}s.
      * @param b byte where each bit corresponds to the ordinal of an Output
      * @return a Set containing the desired Outputs
      */
-    public static Set<Output> decodeByteToSet(byte b) {
-        Output[] enums = Output.class.getEnumConstants();
-        Set<Output> enumSet = EnumSet.noneOf(Output.class);
+    public static Set<OutputId> decodeByteToSet(byte b) {
+        OutputId[] enums = OutputId.class.getEnumConstants();
+        Set<OutputId> enumSet = EnumSet.noneOf(OutputId.class);
         for (int bit = 0; bit < Byte.SIZE; bit++) {
             if ((b & 0xFF & 1 << bit) > 0) {
                 enumSet.add(enums[bit]);

--- a/src/main/java/org/chabala/brick/controllab/Protocol.java
+++ b/src/main/java/org/chabala/brick/controllab/Protocol.java
@@ -30,6 +30,9 @@ final class Protocol {
     static final byte OUTPUT_OFF = (byte) 0b10010000;
     static final byte OUTPUT_ON =  (byte) 0b10010001;
 
+    static final byte STOP_DEPRESSED = (byte) 0x10;
+    static final byte STOP_RELEASED =  (byte) 0x00;
+
     static final int FRAME_SIZE = 19;
 
     private Protocol() {

--- a/src/main/java/org/chabala/brick/controllab/SerialListener.java
+++ b/src/main/java/org/chabala/brick/controllab/SerialListener.java
@@ -50,12 +50,14 @@ class SerialListener implements SerialPortEventListener {
 
     @Override
     public boolean isHandshakeSeen() {
+        boolean returnedEarly = false;
         try {
-            handshakeLatch.await(1, TimeUnit.SECONDS);
+            returnedEarly = handshakeLatch.await(1, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             log.error(e.getMessage(), e);
+            Thread.currentThread().interrupt();
         }
-        return handshakeSeen;
+        return handshakeSeen || returnedEarly;
     }
 
     private void setHandshakeSeen() {

--- a/src/main/java/org/chabala/brick/controllab/SerialListener.java
+++ b/src/main/java/org/chabala/brick/controllab/SerialListener.java
@@ -22,6 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
@@ -36,6 +38,7 @@ class SerialListener implements SerialPortEventListener {
     private final boolean ignoreBadHandshake;
 
     private boolean handshakeSeen = false;
+    private CountDownLatch handshakeLatch = new CountDownLatch(1);
     private StringBuilder handshakeBuilder = new StringBuilder();
 
     SerialListener(SerialPort serialPort, InputManager inputManager) {
@@ -47,7 +50,18 @@ class SerialListener implements SerialPortEventListener {
 
     @Override
     public boolean isHandshakeSeen() {
+        try {
+            handshakeLatch.await(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            log.error(e.getMessage(), e);
+        }
         return handshakeSeen;
+    }
+
+    private void setHandshakeSeen() {
+        handshakeSeen = true;
+        handshakeLatch.countDown();
+        handshakeBuilder = null;
     }
 
     /** {@inheritDoc} */
@@ -75,14 +89,12 @@ class SerialListener implements SerialPortEventListener {
                 if (handshakeBuilder.length() >= Protocol.HANDSHAKE_RESPONSE.length()) {
                     String handshake = handshakeBuilder.toString();
                     if (handshake.endsWith(Protocol.HANDSHAKE_RESPONSE)) {
-                        handshakeSeen = true;
                         log.info(handshake);
-                        handshakeBuilder = null;
+                        setHandshakeSeen();
                     } else {
                         log.error("Bad handshake: {}", handshake);
                         if (ignoreBadHandshake) {
-                            handshakeSeen = true;
-                            handshakeBuilder = null;
+                            setHandshakeSeen();
                         } else {
                             serialPort.close();
                             return;

--- a/src/main/java/org/chabala/brick/controllab/SerialPortWriter.java
+++ b/src/main/java/org/chabala/brick/controllab/SerialPortWriter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2016 Greg Chabala
+ *
+ * This file is part of brick-control-lab.
+ *
+ * brick-control-lab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * brick-control-lab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with brick-control-lab.  If not, see http://www.gnu.org/licenses/.
+ */
+package org.chabala.brick.controllab;
+
+import org.slf4j.Logger;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+
+/**
+ * Owner of all writing activity for a serial port. Manages consistent logging
+ * and ownership of the keep alive monitor for the port.
+ */
+class SerialPortWriter implements Closeable {
+    private final Logger log;
+    private final SerialPort serialPort;
+    private KeepAliveMonitor keepAliveMonitor;
+
+    SerialPortWriter(SerialPort serialPort, Logger log) {
+        this.serialPort = serialPort;
+        this.log = log;
+    }
+
+    void startKeepAlives() {
+        keepAliveMonitor = new KeepAliveMonitor(this);
+    }
+
+    String getPortName() {
+        return serialPort.getPortName();
+    }
+
+    void sendCommand(byte[] bytes, Logger log) throws IOException {
+        if (serialPort == null) {
+            throw new IOException("Not connected to control lab");
+        }
+        if (keepAliveMonitor != null) {
+            keepAliveMonitor.reset();
+        }
+        if (serialPort.isOpen()) {
+            if (log.isInfoEnabled()) {
+                if (bytes.length > 10) {
+                    log.info("TX -> {}", new String(bytes, ISO_8859_1));
+                } else {
+                    StringBuilder sb = new StringBuilder();
+                    for (byte b : bytes) {
+                        sb.append(String.format("0x%02X ", b));
+                    }
+                    log.info("TX -> {}", sb);
+                }
+            }
+            serialPort.write(bytes);
+        }
+    }
+
+    void sendCommand(byte[] bytes) throws IOException {
+        sendCommand(bytes, log);
+    }
+
+    void sendCommand(byte b) throws IOException {
+        sendCommand(new byte[]{b});
+    }
+
+    void sendCommand(byte b, Logger log) throws IOException {
+        sendCommand(new byte[]{b}, log);
+    }
+
+    void sendCommand(byte b1, byte b2) throws IOException {
+        sendCommand(new byte[]{b1, b2});
+    }
+
+    @Override
+    public void close() {
+        if (keepAliveMonitor != null) {
+            keepAliveMonitor.close();
+            keepAliveMonitor = null;
+        }
+    }
+}

--- a/src/main/java/org/chabala/brick/controllab/SerialPortWriter.java
+++ b/src/main/java/org/chabala/brick/controllab/SerialPortWriter.java
@@ -30,6 +30,12 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
  * and ownership of the keep alive monitor for the port.
  */
 class SerialPortWriter implements Closeable {
+    /**
+     * When sending commands longer than this threshold, log them as strings
+     * instead of hex values. In practice, this is only needed for the initial
+     * handshake, which makes more sense to show as a string.
+     */
+    private static final int STRING_LOGGING_THRESHOLD = 10;
     private final Logger log;
     private final SerialPort serialPort;
     private KeepAliveMonitor keepAliveMonitor;
@@ -56,7 +62,7 @@ class SerialPortWriter implements Closeable {
         }
         if (serialPort.isOpen()) {
             if (log.isInfoEnabled()) {
-                if (bytes.length > 10) {
+                if (bytes.length > STRING_LOGGING_THRESHOLD) {
                     log.info("TX -> {}", new String(bytes, ISO_8859_1));
                 } else {
                     StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/chabala/brick/controllab/StopButton.java
+++ b/src/main/java/org/chabala/brick/controllab/StopButton.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2016 Greg Chabala
+ *
+ * This file is part of brick-control-lab.
+ *
+ * brick-control-lab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * brick-control-lab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with brick-control-lab.  If not, see http://www.gnu.org/licenses/.
+ */
+package org.chabala.brick.controllab;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Handle for stop button on a specific control lab instance. Obtain via {@link ControlLab#getStopButton()}.
+ */
+public class StopButton {
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final Set<StopButtonListener> stopButtonListeners;
+    private boolean stopDepressed = false;
+
+    StopButton(InputManager inputManager) {
+        stopButtonListeners = Collections.synchronizedSet(new HashSet<>(2));
+        inputManager.setStopButtonCallback(this::processStopButton);
+    }
+
+    /**
+     * Attach a listener for {@link StopButtonEvent}s.
+     *
+     * <p>Multiple listeners are allowed. A listener instance will only be registered
+     * once even if it is added multiple times.
+     * @param listener listener to add
+     */
+    public void addListener(StopButtonListener listener) {
+        stopButtonListeners.add(listener);
+    }
+
+    /**
+     * Remove a listener for {@link StopButtonEvent}s.
+     * @param listener listener to remove
+     */
+    public void removeListener(StopButtonListener listener) {
+        stopButtonListeners.remove(listener);
+    }
+
+    /**
+     * Returns current status of stop button.
+     * @return true if the stop button is in depressed state, false otherwise
+     */
+    public boolean isStopDepressed() {
+        return stopDepressed;
+    }
+
+    @SuppressWarnings("squid:S2629")
+    private void processStopButton(byte b) {
+        if (0x00 != b) {
+            if (!stopDepressed) {
+                StopButtonEvent event = new StopButtonEvent(this, b);
+                synchronized (stopButtonListeners) {
+                    stopButtonListeners.forEach(l -> l.stopButtonPressed(event));
+                }
+                log.info("Stop button depressed {}", String.format("0x%02X", b));
+                stopDepressed = true;
+            }
+        } else {
+            if (stopDepressed) {
+                StopButtonEvent event = new StopButtonEvent(this, b);
+                synchronized (stopButtonListeners) {
+                    stopButtonListeners.forEach(l -> l.stopButtonReleased(event));
+                }
+                log.info("Stop button released {}", String.format("0x%02X", b));
+                stopDepressed = false;
+            }
+        }
+    }
+}

--- a/src/main/java/org/chabala/brick/controllab/StopButton.java
+++ b/src/main/java/org/chabala/brick/controllab/StopButton.java
@@ -70,19 +70,19 @@ public class StopButton {
         if (0x00 != b) {
             if (!stopDepressed) {
                 StopButtonEvent event = new StopButtonEvent(this, b);
+                log.info("Stop button depressed {}", String.format("0x%02X", b));
                 synchronized (stopButtonListeners) {
                     stopButtonListeners.forEach(l -> l.stopButtonPressed(event));
                 }
-                log.info("Stop button depressed {}", String.format("0x%02X", b));
                 stopDepressed = true;
             }
         } else {
             if (stopDepressed) {
                 StopButtonEvent event = new StopButtonEvent(this, b);
+                log.info("Stop button released {}", String.format("0x%02X", b));
                 synchronized (stopButtonListeners) {
                     stopButtonListeners.forEach(l -> l.stopButtonReleased(event));
                 }
-                log.info("Stop button released {}", String.format("0x%02X", b));
                 stopDepressed = false;
             }
         }

--- a/src/main/java/org/chabala/brick/controllab/StopButton.java
+++ b/src/main/java/org/chabala/brick/controllab/StopButton.java
@@ -25,6 +25,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.chabala.brick.controllab.Protocol.STOP_RELEASED;
+
 /**
  * Handle for stop button on a specific control lab instance. Obtain via {@link ControlLab#getStopButton()}.
  */
@@ -67,7 +69,7 @@ public class StopButton {
 
     @SuppressWarnings("squid:S2629")
     private void processStopButton(byte b) {
-        if (0x00 != b) {
+        if (STOP_RELEASED != b) {
             if (!stopDepressed) {
                 StopButtonEvent event = new StopButtonEvent(this, b);
                 log.info("Stop button depressed {}", String.format("0x%02X", b));

--- a/src/main/java/org/chabala/brick/controllab/StopButtonEvent.java
+++ b/src/main/java/org/chabala/brick/controllab/StopButtonEvent.java
@@ -40,10 +40,15 @@ public class StopButtonEvent extends EventObject {
         this.rawValue = rawValue;
     }
 
+    /**
+     * The raw data that signaled this event.
+     * @return The raw data that signaled this event.
+     */
     public byte getRawValue() {
         return rawValue;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return "StopButtonEvent{" +

--- a/src/main/java/org/chabala/brick/controllab/sensor/LightSensorEvent.java
+++ b/src/main/java/org/chabala/brick/controllab/sensor/LightSensorEvent.java
@@ -18,10 +18,10 @@
  */
 package org.chabala.brick.controllab.sensor;
 
-import org.chabala.brick.controllab.Input;
+import org.chabala.brick.controllab.InputId;
 
 /**
- * The event triggered by receiving a {@link SensorValue} from an {@link Input}
+ * The event triggered by receiving a {@link SensorValue} from an {@link InputId}
  * that is known to be a {@link LightSensor}.
  */
 public class LightSensorEvent extends SensorEvent<LightSensor> {

--- a/src/main/java/org/chabala/brick/controllab/sensor/SensorEvent.java
+++ b/src/main/java/org/chabala/brick/controllab/sensor/SensorEvent.java
@@ -18,7 +18,7 @@
  */
 package org.chabala.brick.controllab.sensor;
 
-import org.chabala.brick.controllab.Input;
+import org.chabala.brick.controllab.InputId;
 
 import java.util.EventObject;
 import java.util.function.Function;
@@ -26,7 +26,7 @@ import java.util.function.Function;
 import static org.chabala.brick.controllab.BinaryStringFormatter.printInBinary;
 
 /**
- * The event triggered by receiving a {@link SensorValue} from an {@link Input}.
+ * The event triggered by receiving a {@link SensorValue} from an {@link InputId}.
  */
 public class SensorEvent<T extends SensorValue> extends EventObject {
 
@@ -42,7 +42,7 @@ public class SensorEvent<T extends SensorValue> extends EventObject {
      * @param newValue The new value from this input, as a two byte array.
      * @param value    The new value wrapped in the SensorValue class.
      */
-    public SensorEvent(Input input, byte[] oldValue, byte[] newValue, T value) {
+    public SensorEvent(InputId input, byte[] oldValue, byte[] newValue, T value) {
         super(input);
         this.oldValue = oldValue;
         this.newValue = newValue;
@@ -66,8 +66,8 @@ public class SensorEvent<T extends SensorValue> extends EventObject {
      * The input port that triggered this event.
      * @return the input port that triggered this event.
      */
-    public Input getInput() {
-        return (Input) getSource();
+    public InputId getInput() {
+        return (InputId) getSource();
     }
 
     /**

--- a/src/main/java/org/chabala/brick/controllab/sensor/SensorEvent.java
+++ b/src/main/java/org/chabala/brick/controllab/sensor/SensorEvent.java
@@ -27,6 +27,7 @@ import static org.chabala.brick.controllab.BinaryStringFormatter.printInBinary;
 
 /**
  * The event triggered by receiving a {@link SensorValue} from an {@link InputId}.
+ * @param <T> specific {@link SensorValue} subclass contained in this event
  */
 public class SensorEvent<T extends SensorValue> extends EventObject {
 

--- a/src/main/java/org/chabala/brick/controllab/sensor/SensorValue.java
+++ b/src/main/java/org/chabala/brick/controllab/sensor/SensorValue.java
@@ -18,10 +18,10 @@
  */
 package org.chabala.brick.controllab.sensor;
 
-import org.chabala.brick.controllab.Input;
+import org.chabala.brick.controllab.InputId;
 
 /**
- * The values obtained from reading an {@link Input}.
+ * The values obtained from reading an {@link InputId}.
  */
 public interface SensorValue {
 

--- a/src/main/java/org/chabala/brick/controllab/sensor/SensorValueImpl.java
+++ b/src/main/java/org/chabala/brick/controllab/sensor/SensorValueImpl.java
@@ -45,14 +45,19 @@ class SensorValueImpl implements SensorValue {
         return statusCode;
     }
 
+    /** Analog value is 10 bits, so we steal 2 bits from the low byte. */
+    private static final int HIGH_SHIFT = 2;
+    private static final int LOW_SHIFT = Byte.SIZE - HIGH_SHIFT;
+    private static final int STATUS_MASK = (1 << LOW_SHIFT) - 1;
+
     private int extractValue(byte b1, byte b2) {
-        int high = (b1 & 0xFF) << 2; //000000xxxxxxxx00
-        int low = (b2 & 0xFF) >> 6;  //00000000000000xx
+        int high = Byte.toUnsignedInt(b1) << HIGH_SHIFT; //000000xxxxxxxx00
+        int low = Byte.toUnsignedInt(b2) >>> LOW_SHIFT;  //00000000000000xx
         return high + low;
     }
 
     private int extractStatus(byte b2) {
-        return b2 & 0x3F;
+        return b2 & STATUS_MASK;
     }
 
     @Override

--- a/src/main/java/org/chabala/brick/controllab/sensor/TouchSensorEvent.java
+++ b/src/main/java/org/chabala/brick/controllab/sensor/TouchSensorEvent.java
@@ -18,10 +18,10 @@
  */
 package org.chabala.brick.controllab.sensor;
 
-import org.chabala.brick.controllab.Input;
+import org.chabala.brick.controllab.InputId;
 
 /**
- * The event triggered by receiving a {@link SensorValue} from an {@link Input}
+ * The event triggered by receiving a {@link SensorValue} from an {@link InputId}
  * that is known to be a {@link TouchSensor}.
  */
 public class TouchSensorEvent extends SensorEvent<TouchSensor> {

--- a/src/main/java/org/chabala/brick/controllab/sensor/TouchSensorEvent.java
+++ b/src/main/java/org/chabala/brick/controllab/sensor/TouchSensorEvent.java
@@ -25,6 +25,11 @@ import org.chabala.brick.controllab.InputId;
  * that is known to be a {@link TouchSensor}.
  */
 public class TouchSensorEvent extends SensorEvent<TouchSensor> {
+    /**
+     * Creates a TouchSensorEvent from a generic {@link SensorEvent}, and wraps
+     * the {@link SensorValue} in the appropriate subclass.
+     * @param sensorEvent generic sensor event
+     */
     public TouchSensorEvent(SensorEvent<SensorValue> sensorEvent) {
         super(sensorEvent, TouchSensor::new);
     }

--- a/src/main/java/org/chabala/brick/controllab/sensor/package-info.java
+++ b/src/main/java/org/chabala/brick/controllab/sensor/package-info.java
@@ -16,21 +16,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with brick-control-lab.  If not, see http://www.gnu.org/licenses/.
  */
-package org.chabala.brick.controllab.sensor;
-
-import org.chabala.brick.controllab.InputId;
-
 /**
- * The event triggered by receiving a {@link SensorValue} from an {@link InputId}
- * that is known to be a {@link LightSensor}.
+ * Contains listeners, events, and event values for the input ports
+ * and sensor specific subclasses to interpret the values.
  */
-public class LightSensorEvent extends SensorEvent<LightSensor> {
-    /**
-     * Creates a LightSensorEvent from a generic {@link SensorEvent}, and wraps
-     * the {@link SensorValue} in the appropriate subclass.
-     * @param sensorEvent generic sensor event
-     */
-    public LightSensorEvent(SensorEvent<SensorValue> sensorEvent) {
-        super(sensorEvent, LightSensor::new);
-    }
-}
+package org.chabala.brick.controllab.sensor;

--- a/src/test/java/org/chabala/brick/controllab/BinaryStringFormatterTest.java
+++ b/src/test/java/org/chabala/brick/controllab/BinaryStringFormatterTest.java
@@ -31,10 +31,10 @@ public class BinaryStringFormatterTest {
 
     @Test
     public void testPrintByteInBinary() throws Exception {
-        assertThat(printByteInBinary(0b00000000), is("00000000"));
-        assertThat(printByteInBinary(0b00000001), is("00000001"));
-        assertThat(printByteInBinary(0b10000000), is("10000000"));
-        assertThat(printByteInBinary(0b10000001), is("10000001"));
-        assertThat(printByteInBinary(0b10110111), is("10110111"));
+        assertThat(printByteInBinary((byte) 0b00000000), is("00000000"));
+        assertThat(printByteInBinary((byte) 0b00000001), is("00000001"));
+        assertThat(printByteInBinary((byte) 0b10000000), is("10000000"));
+        assertThat(printByteInBinary((byte) 0b10000001), is("10000001"));
+        assertThat(printByteInBinary((byte) 0b10110111), is("10110111"));
     }
 }

--- a/src/test/java/org/chabala/brick/controllab/ControlLabIT.java
+++ b/src/test/java/org/chabala/brick/controllab/ControlLabIT.java
@@ -79,14 +79,14 @@ public class ControlLabIT {
             controlLab.setOutputDirection(Direction.LEFT, EnumSet.of(OutputId.E, OutputId.F));
             Thread.sleep(ONE_SECOND);
 
-            controlLab.setOutputDirection(Direction.REVERSE, EnumSet.of(OutputId.E, OutputId.F, OutputId.G, OutputId.H));
+            controlLab.getOutputGroup(EnumSet.range(OutputId.E, OutputId.H)).reverseDirection();
             Thread.sleep(ONE_SECOND);
 
-            controlLab.setOutputDirection(Direction.RIGHT, EnumSet.of(OutputId.H));
+            controlLab.getOutput(OutputId.H).setDirection(Direction.RIGHT);
             Thread.sleep(ONE_SECOND);
 
-            for (OutputId o : Arrays.asList(OutputId.H, OutputId.G, OutputId.F, OutputId.E)) {
-                controlLab.turnOutputOff(EnumSet.of(o));
+            for (OutputId o : descendingRange(OutputId.H, OutputId.E)) {
+                controlLab.getOutput(o).turnOff();
                 Thread.sleep(ONE_SECOND);
             }
 
@@ -237,32 +237,30 @@ public class ControlLabIT {
             }
             Thread.sleep(ONE_SECOND);
             controlLab.getInput(InputId.I1).addListener((TouchSensorListener) sensorEvent -> stop.set(true));
-            Set<OutputId> outputSet = OutputId.ALL;
+            Output outputs = controlLab.getOutputGroup(OutputId.ALL);
             while (!stop.get()) {
-                controlLab.setOutputPowerLevel(PowerLevel.P8, outputSet);
-                controlLab.setOutputDirection(Direction.RIGHT, outputSet);
-                controlLab.turnOutputOn(outputSet);
+                outputs.setPowerLevel(PowerLevel.P8).setDirection(Direction.RIGHT).turnOn();
                 Thread.sleep(ONE_SECOND);
                 if (stop.get()) {
                     return;
                 }
 
-                for (PowerLevel p : descendingRange(PowerLevel.P1, PowerLevel.P7)) {
-                    controlLab.setOutputPowerLevel(p, outputSet);
+                for (PowerLevel p : descendingRange(PowerLevel.P7, PowerLevel.P1)) {
+                    outputs.setPowerLevel(p);
                     Thread.sleep(ONE_SECOND);
                     if (stop.get()) {
                         return;
                     }
                 }
 
-                controlLab.setOutputDirection(Direction.REVERSE, outputSet);
+                outputs.reverseDirection();
                 Thread.sleep(ONE_SECOND);
                 if (stop.get()) {
                     return;
                 }
 
                 for (PowerLevel p : EnumSet.range(PowerLevel.P2, PowerLevel.P8)) {
-                    controlLab.setOutputPowerLevel(p, outputSet);
+                    outputs.setPowerLevel(p);
                     Thread.sleep(ONE_SECOND);
                     if (stop.get()) {
                         return;

--- a/src/test/java/org/chabala/brick/controllab/ControlLabIT.java
+++ b/src/test/java/org/chabala/brick/controllab/ControlLabIT.java
@@ -102,6 +102,23 @@ public class ControlLabIT {
         }
     }
 
+    @Test
+    public void testFluentOutputControl() throws Exception {
+        try (ControlLab controlLab = ControlLab.newControlLab()) {
+            try {
+                controlLab.open(choosePort(controlLab));
+            } catch (IOException e) {
+                assumeNoException(e);
+            }
+            Output output = controlLab.getOutput(OutputId.A);
+            output.setDirection(Direction.LEFT).setPowerLevel(PowerLevel.P2).turnOn();
+            Thread.sleep(ONE_SECOND * 5);
+
+            output.reverseDirection().setPowerLevel(PowerLevel.P8);
+            Thread.sleep(ONE_SECOND * 5);
+        }
+    }
+
     @Ignore("Requires interaction with stop button to complete, only run manually")
     @Test
     public void testControlLabInputs() throws Exception {

--- a/src/test/java/org/chabala/brick/controllab/ControlLabIT.java
+++ b/src/test/java/org/chabala/brick/controllab/ControlLabIT.java
@@ -63,9 +63,9 @@ public class ControlLabIT {
                 assumeNoException(e);
             }
             Thread.sleep(ONE_SECOND * 3);
-            controlLab.turnOutputOn(Output.ALL);
+            controlLab.turnOutputOn(OutputId.ALL);
             Thread.sleep(ONE_SECOND * 3);
-            controlLab.turnOutputOff(EnumSet.range(Output.A, Output.D));
+            controlLab.turnOutputOff(EnumSet.range(OutputId.A, OutputId.D));
             Thread.sleep(ONE_SECOND * 3);
         }
     }
@@ -80,24 +80,24 @@ public class ControlLabIT {
             }
             Thread.sleep(ONE_SECOND);
 
-            controlLab.turnOutputOn(Output.ALL);
+            controlLab.turnOutputOn(OutputId.ALL);
             Thread.sleep(ONE_SECOND);
 
-            controlLab.setOutputDirection(Direction.LEFT, EnumSet.of(Output.E, Output.F));
+            controlLab.setOutputDirection(Direction.LEFT, EnumSet.of(OutputId.E, OutputId.F));
             Thread.sleep(ONE_SECOND);
 
-            controlLab.setOutputDirection(Direction.REVERSE, EnumSet.of(Output.E, Output.F, Output.G, Output.H));
+            controlLab.setOutputDirection(Direction.REVERSE, EnumSet.of(OutputId.E, OutputId.F, OutputId.G, OutputId.H));
             Thread.sleep(ONE_SECOND);
 
-            controlLab.setOutputDirection(Direction.RIGHT, EnumSet.of(Output.H));
+            controlLab.setOutputDirection(Direction.RIGHT, EnumSet.of(OutputId.H));
             Thread.sleep(ONE_SECOND);
 
-            for (Output o : Arrays.asList(Output.H, Output.G, Output.F, Output.E)) {
+            for (OutputId o : Arrays.asList(OutputId.H, OutputId.G, OutputId.F, OutputId.E)) {
                 controlLab.turnOutputOff(EnumSet.of(o));
                 Thread.sleep(ONE_SECOND);
             }
 
-            controlLab.turnOutputOff(EnumSet.range(Output.A, Output.D));
+            controlLab.turnOutputOff(EnumSet.range(OutputId.A, OutputId.D));
             Thread.sleep(ONE_SECOND * 5);
         }
     }
@@ -157,19 +157,19 @@ public class ControlLabIT {
             }
             Thread.sleep(ONE_SECOND);
 
-            controlLab.setOutputPowerLevel(PowerLevel.P1, EnumSet.of(Output.A));
-            controlLab.turnOutputOn(EnumSet.of(Output.A));
+            controlLab.setOutputPowerLevel(PowerLevel.P1, EnumSet.of(OutputId.A));
+            controlLab.turnOutputOn(EnumSet.of(OutputId.A));
             Thread.sleep(ONE_SECOND);
 
             for (PowerLevel p : EnumSet.range(PowerLevel.P2, PowerLevel.P8)) {
-                controlLab.setOutputPowerLevel(p, EnumSet.of(Output.A));
+                controlLab.setOutputPowerLevel(p, EnumSet.of(OutputId.A));
                 Thread.sleep(ONE_SECOND);
             }
 
-            controlLab.setOutputPowerLevel(PowerLevel.P0, EnumSet.of(Output.A));
+            controlLab.setOutputPowerLevel(PowerLevel.P0, EnumSet.of(OutputId.A));
             Thread.sleep(ONE_SECOND);
 
-            controlLab.turnOutputOn(EnumSet.of(Output.A));
+            controlLab.turnOutputOn(EnumSet.of(OutputId.A));
             Thread.sleep(ONE_SECOND);
         }
     }
@@ -208,7 +208,7 @@ public class ControlLabIT {
             }
             Thread.sleep(ONE_SECOND);
             controlLab.addSensorListener(Input.I1, (TouchSensorListener) sensorEvent -> stop.set(true));
-            Set<Output> outputSet = Output.ALL;
+            Set<OutputId> outputSet = OutputId.ALL;
             while (!stop.get()) {
                 controlLab.setOutputPowerLevel(PowerLevel.P8, outputSet);
                 controlLab.setOutputDirection(Direction.RIGHT, outputSet);

--- a/src/test/java/org/chabala/brick/controllab/ControlLabIT.java
+++ b/src/test/java/org/chabala/brick/controllab/ControlLabIT.java
@@ -32,10 +32,10 @@ import java.util.stream.Collectors;
 
 import static javax.management.timer.Timer.ONE_SECOND;
 import static org.awaitility.Awaitility.await;
+import static org.chabala.brick.controllab.PortChooser.choosePort;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeNoException;
-import static org.junit.Assume.assumeThat;
 
 /**
  * Integration tests for the {@link ControlLab}.
@@ -46,13 +46,6 @@ import static org.junit.Assume.assumeThat;
 @SuppressWarnings({"squid:S2699","squid:S2925"})
 public class ControlLabIT {
     private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-    private String choosePort(ControlLab controlLab) {
-        List<String> availablePorts = controlLab.getAvailablePorts();
-        assumeThat("a serial port should be available", availablePorts, is(not(empty())));
-        log.debug("Available ports: {}", String.join(", ", availablePorts));
-        return availablePorts.get(0);
-    }
 
     @Test
     public void testTurnOutputOff() throws Exception {

--- a/src/test/java/org/chabala/brick/controllab/ControlLabIT.java
+++ b/src/test/java/org/chabala/brick/controllab/ControlLabIT.java
@@ -130,13 +130,13 @@ public class ControlLabIT {
                 assumeNoException(e);
             }
             controlLab.getStopButton().addListener(stopButtonEvent -> stop.set(true));
-            Map<Input, String> lastTouchValues = Collections.synchronizedMap(new EnumMap<>(Input.class));
-            List<Input> passiveInputs = Arrays.stream(Input.values())
-                                              .filter(i -> i.getInputType().equals(InputType.PASSIVE))
-                                              .collect(Collectors.toList());
+            Map<InputId, String> lastTouchValues = Collections.synchronizedMap(new EnumMap<>(InputId.class));
+            List<InputId> passiveInputs = Arrays.stream(InputId.values())
+                                                .filter(i -> i.getInputType().equals(InputType.PASSIVE))
+                                                .collect(Collectors.toList());
             passiveInputs.forEach(i -> lastTouchValues.put(i, ""));
             TouchSensorListener touchSensorListener = sensorEvent -> {
-                Input input = sensorEvent.getInput();
+                InputId input = sensorEvent.getInput();
                 String newValue = sensorEvent.getValue().touchStatus();
                 if ("".equals(newValue)) {
                     return;
@@ -148,10 +148,10 @@ public class ControlLabIT {
             };
             passiveInputs.forEach(i -> controlLab.addSensorListener(i, touchSensorListener));
             LightSensorListener lightSensorListener = sensorEvent -> {
-                Input input = sensorEvent.getInput();
+                InputId input = sensorEvent.getInput();
                 log.info("{} value changed: {}", input, sensorEvent.getValue());
             };
-            Arrays.stream(Input.values())
+            Arrays.stream(InputId.values())
                   .filter(i -> i.getInputType().equals(InputType.ACTIVE))
                   .forEach(i -> controlLab.addSensorListener(i, lightSensorListener));
 
@@ -172,7 +172,7 @@ public class ControlLabIT {
             controlLab.getStopButton().addListener(stopButtonEvent -> stop.set(true));
             SensorListener sensorListener = sensorEvent ->
                     log.info("{} value changed: {}", sensorEvent.getInput(), sensorEvent.getValue());
-            Arrays.stream(Input.values())
+            Arrays.stream(InputId.values())
                   .forEach(i -> controlLab.addSensorListener(i, sensorListener));
 
             await().forever().until(stop::get);
@@ -239,7 +239,7 @@ public class ControlLabIT {
                 assumeNoException(e);
             }
             Thread.sleep(ONE_SECOND);
-            controlLab.addSensorListener(Input.I1, (TouchSensorListener) sensorEvent -> stop.set(true));
+            controlLab.addSensorListener(InputId.I1, (TouchSensorListener) sensorEvent -> stop.set(true));
             Set<OutputId> outputSet = OutputId.ALL;
             while (!stop.get()) {
                 controlLab.setOutputPowerLevel(PowerLevel.P8, outputSet);

--- a/src/test/java/org/chabala/brick/controllab/ControlLabIT.java
+++ b/src/test/java/org/chabala/brick/controllab/ControlLabIT.java
@@ -129,7 +129,7 @@ public class ControlLabIT {
             } catch (IOException e) {
                 assumeNoException(e);
             }
-            controlLab.addStopButtonListener(stopButtonEvent -> stop.set(true));
+            controlLab.getStopButton().addListener(stopButtonEvent -> stop.set(true));
             Map<Input, String> lastTouchValues = Collections.synchronizedMap(new EnumMap<>(Input.class));
             List<Input> passiveInputs = Arrays.stream(Input.values())
                                               .filter(i -> i.getInputType().equals(InputType.PASSIVE))
@@ -169,7 +169,7 @@ public class ControlLabIT {
             } catch (IOException e) {
                 assumeNoException(e);
             }
-            controlLab.addStopButtonListener(stopButtonEvent -> stop.set(true));
+            controlLab.getStopButton().addListener(stopButtonEvent -> stop.set(true));
             SensorListener sensorListener = sensorEvent ->
                     log.info("{} value changed: {}", sensorEvent.getInput(), sensorEvent.getValue());
             Arrays.stream(Input.values())
@@ -189,19 +189,19 @@ public class ControlLabIT {
             }
             Thread.sleep(ONE_SECOND);
 
-            controlLab.setOutputPowerLevel(PowerLevel.P1, EnumSet.of(OutputId.A));
-            controlLab.turnOutputOn(EnumSet.of(OutputId.A));
+            Output output = controlLab.getOutput(OutputId.A);
+            output.setPowerLevel(PowerLevel.P1).turnOn();
             Thread.sleep(ONE_SECOND);
 
             for (PowerLevel p : EnumSet.range(PowerLevel.P2, PowerLevel.P8)) {
-                controlLab.setOutputPowerLevel(p, EnumSet.of(OutputId.A));
+                output.setPowerLevel(p);
                 Thread.sleep(ONE_SECOND);
             }
 
-            controlLab.setOutputPowerLevel(PowerLevel.P0, EnumSet.of(OutputId.A));
+            output.setPowerLevel(PowerLevel.P0);
             Thread.sleep(ONE_SECOND);
 
-            controlLab.turnOutputOn(EnumSet.of(OutputId.A));
+            output.turnOn();
             Thread.sleep(ONE_SECOND);
         }
     }
@@ -216,7 +216,7 @@ public class ControlLabIT {
             } catch (IOException e) {
                 assumeNoException(e);
             }
-            controlLab.addStopButtonListener(stopButtonEvent -> stop.set(true));
+            controlLab.getStopButton().addListener(stopButtonEvent -> stop.set(true));
             await().forever().until(stop::get);
         }
     }

--- a/src/test/java/org/chabala/brick/controllab/ControlLabIT.java
+++ b/src/test/java/org/chabala/brick/controllab/ControlLabIT.java
@@ -146,14 +146,17 @@ public class ControlLabIT {
                     log.info("{} value changed: {}", input, newValue);
                 }
             };
-            passiveInputs.forEach(i -> controlLab.addSensorListener(i, touchSensorListener));
+            for (InputId passiveInput : passiveInputs) {
+                controlLab.getInput(passiveInput).addListener(touchSensorListener);
+            }
             LightSensorListener lightSensorListener = sensorEvent -> {
                 InputId input = sensorEvent.getInput();
                 log.info("{} value changed: {}", input, sensorEvent.getValue());
             };
             Arrays.stream(InputId.values())
                   .filter(i -> i.getInputType().equals(InputType.ACTIVE))
-                  .forEach(i -> controlLab.addSensorListener(i, lightSensorListener));
+                  .map(controlLab::getInput)
+                  .forEach(i -> i.addListener(lightSensorListener));
 
             await().forever().until(stop::get);
         }
@@ -173,7 +176,8 @@ public class ControlLabIT {
             SensorListener sensorListener = sensorEvent ->
                     log.info("{} value changed: {}", sensorEvent.getInput(), sensorEvent.getValue());
             Arrays.stream(InputId.values())
-                  .forEach(i -> controlLab.addSensorListener(i, sensorListener));
+                  .map(controlLab::getInput)
+                  .forEach(i -> i.addListener(sensorListener));
 
             await().forever().until(stop::get);
         }
@@ -239,7 +243,7 @@ public class ControlLabIT {
                 assumeNoException(e);
             }
             Thread.sleep(ONE_SECOND);
-            controlLab.addSensorListener(InputId.I1, (TouchSensorListener) sensorEvent -> stop.set(true));
+            controlLab.getInput(InputId.I1).addListener((TouchSensorListener) sensorEvent -> stop.set(true));
             Set<OutputId> outputSet = OutputId.ALL;
             while (!stop.get()) {
                 controlLab.setOutputPowerLevel(PowerLevel.P8, outputSet);

--- a/src/test/java/org/chabala/brick/controllab/ControlLabTest.java
+++ b/src/test/java/org/chabala/brick/controllab/ControlLabTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
 
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -64,11 +65,14 @@ public class ControlLabTest {
     @Mock
     private SerialPortEventListener listener;
 
+    @Mock
+    private Logger log;
+
     private ControlLab controlLab;
 
     @Before
     public void setUp() {
-        controlLab = new ControlLabImpl(portFactory, inputManager, (sp, inputManager) -> listener);
+        controlLab = new ControlLabImpl(log, portFactory, inputManager, (sp, inputManager) -> listener);
     }
 
     @After

--- a/src/test/java/org/chabala/brick/controllab/ControlLabTest.java
+++ b/src/test/java/org/chabala/brick/controllab/ControlLabTest.java
@@ -29,11 +29,13 @@ import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
 import static org.mockito.Mockito.*;
 
 /**
@@ -57,12 +59,15 @@ public class ControlLabTest {
     private SerialPort serialPort;
 
     @Mock
+    private jssc.SerialPort innerSerialPort;
+
+    @Mock
     private SerialPortEventListener listener;
 
     private ControlLab controlLab;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         controlLab = new ControlLabImpl(portFactory, inputManager, (sp, inputManager) -> listener);
     }
 
@@ -94,5 +99,58 @@ public class ControlLabTest {
         controlLab.open(portName);
         verify(serialPort, times(1)).openPort();
         verify(serialPort, times(1)).addEventListener(listener);
+    }
+
+    @Test
+    public void testGetOutput() {
+        OutputId outputId = OutputId.A;
+        Output output = controlLab.getOutput(outputId);
+        assertThat(output.getOutputIdSet(), contains(outputId));
+    }
+
+    @Test
+    public void testGetOutputGroupDelegatesInTheSingleCase() {
+        OutputId outputId = OutputId.B;
+        Output output = controlLab.getOutput(outputId);
+        assumeThat(output.getOutputIdSet(), contains(outputId));
+        Output outputGroup = controlLab.getOutputGroup(EnumSet.of(outputId));
+        assertThat(outputGroup.getOutputIdSet(), contains(outputId));
+        assertThat(outputGroup, is(output));
+    }
+
+    @Test
+    public void testGetOutputGroup() {
+        Output outputGroup = controlLab.getOutputGroup(EnumSet.of(OutputId.C, OutputId.F));
+        assertThat(outputGroup.getOutputIdSet(), contains(OutputId.C, OutputId.F));
+    }
+
+    @Test
+    public void testGetConnectedPortNameWhenNotConnected() {
+        assertThat(controlLab.getConnectedPortName(), is(""));
+    }
+
+    @Test
+    public void testGetConnectedPortNameWhenConnected() throws Exception {
+        final String portName = "two";
+        when(portFactory.getSerialPort(portName)).thenReturn(serialPort);
+        when(serialPort.getPortName()).thenReturn(portName);
+        when(listener.isHandshakeSeen()).thenAnswer(i -> true);
+        controlLab.open(portName);
+        assertThat(controlLab.getConnectedPortName(), is(portName));
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(controlLab + "", containsString("Port=null"));
+    }
+
+    @Test
+    public void testToStringWhenConnected() throws Exception {
+        final String portName = "cool_port_1";
+        when(portFactory.getSerialPort(portName)).thenReturn(new JsscSerialPort(innerSerialPort));
+        when(innerSerialPort.getPortName()).thenReturn(portName);
+        when(listener.isHandshakeSeen()).thenAnswer(i -> true);
+        controlLab.open(portName);
+        assertThat(controlLab + "", containsString(portName));
     }
 }

--- a/src/test/java/org/chabala/brick/controllab/ControlLabTest.java
+++ b/src/test/java/org/chabala/brick/controllab/ControlLabTest.java
@@ -85,6 +85,7 @@ public class ControlLabTest {
         AtomicBoolean handshakeSeen = new AtomicBoolean(false);
         when(portFactory.getSerialPort(portName)).thenReturn(serialPort);
         when(serialPort.getPortName()).thenReturn(portName);
+        when(serialPort.isOpen()).thenReturn(true);
         when(serialPort.write(Protocol.HANDSHAKE_CHALLENGE.getBytes())).thenAnswer((Answer<Boolean>) invocation -> {
             handshakeSeen.set(true);
             return true;

--- a/src/test/java/org/chabala/brick/controllab/InputIdTest.java
+++ b/src/test/java/org/chabala/brick/controllab/InputIdTest.java
@@ -27,27 +27,27 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 /**
- * Testing {@link Input}.
+ * Testing {@link InputId}.
  */
-public class InputTest {
+public class InputIdTest {
 
     @Test
     public void testThereAreEightInputs() throws Exception {
-        assertThat(Input.values(), arrayWithSize(8));
+        assertThat(InputId.values(), arrayWithSize(8));
     }
 
     @Test
     public void testThereAreFourPassiveInputs() throws Exception {
-        assertThat(Arrays.stream(Input.values())
-                   .map(Input::getInputType)
+        assertThat(Arrays.stream(InputId.values())
+                   .map(InputId::getInputType)
                    .filter(InputType.PASSIVE::equals)
                    .collect(Collectors.toList()), hasSize(4));
     }
 
     @Test
     public void testThereAreFourActiveInputs() throws Exception {
-        assertThat(Arrays.stream(Input.values())
-                   .map(Input::getInputType)
+        assertThat(Arrays.stream(InputId.values())
+                   .map(InputId::getInputType)
                    .filter(InputType.ACTIVE::equals)
                    .collect(Collectors.toList()), hasSize(4));
     }

--- a/src/test/java/org/chabala/brick/controllab/InputTest.java
+++ b/src/test/java/org/chabala/brick/controllab/InputTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2016 Greg Chabala
+ *
+ * This file is part of brick-control-lab.
+ *
+ * brick-control-lab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * brick-control-lab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with brick-control-lab.  If not, see http://www.gnu.org/licenses/.
+ */
+package org.chabala.brick.controllab;
+
+import org.chabala.brick.controllab.sensor.SensorListener;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Testing {@link Input}.
+ */
+public class InputTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Mock
+    private InputManager inputManager;
+
+    @Mock
+    private SensorListener listener;
+
+    private InputId inputId;
+
+    private Input input;
+
+    private RandomEnum randomEnum = new RandomEnum();
+
+    @Before
+    public void setUp() {
+        inputId = randomEnum.get(InputId.class);
+        input = new Input(inputManager, inputId);
+    }
+
+    @After
+    public void tearDown() {
+        input = null;
+        inputId = null;
+    }
+
+    @Test
+    public void testAddListener() {
+        input.addListener(listener);
+        verify(inputManager, times(1)).addSensorListener(inputId, listener);
+    }
+
+    @Test
+    public void testRemoveListener() {
+        input.removeListener(listener);
+        verify(inputManager, times(1)).removeSensorListener(inputId, listener);
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(input + "", containsString("inputId=" + inputId.name()));
+    }
+}

--- a/src/test/java/org/chabala/brick/controllab/OutputIdTest.java
+++ b/src/test/java/org/chabala/brick/controllab/OutputIdTest.java
@@ -27,47 +27,47 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
 
 /**
- * Test the encoding and decoding methods of {@link Output}.
+ * Test the encoding and decoding methods of {@link OutputId}.
  */
-public class OutputTest {
+public class OutputIdTest {
 
     @Test
     public void testAllOutputSetEncodesByteWithAllBitsSet() throws Exception {
-        assertThat(Output.encodeSetToByte(Output.ALL), is((byte) 0b11111111));
+        assertThat(OutputId.encodeSetToByte(OutputId.ALL), is((byte) 0b11111111));
     }
 
     @Test
     public void testOutputAEncodesByteWithLowBitSet() throws Exception {
-        assertThat(Output.encodeSetToByte(EnumSet.of(Output.A)), is((byte) 0b00000001));
+        assertThat(OutputId.encodeSetToByte(EnumSet.of(OutputId.A)), is((byte) 0b00000001));
     }
 
     @Test
     public void testOutputHEncodesByteWithHighBitSet() throws Exception {
-        assertThat(Output.encodeSetToByte(EnumSet.of(Output.H)), is((byte) 0b10000000));
+        assertThat(OutputId.encodeSetToByte(EnumSet.of(OutputId.H)), is((byte) 0b10000000));
     }
 
     @Test
     public void testByteWithAllBitsSetDecodesToAllOutputs() throws Exception {
-        assertThat(Output.decodeByteToSet((byte) 0b11111111), is(Output.ALL));
+        assertThat(OutputId.decodeByteToSet((byte) 0b11111111), is(OutputId.ALL));
     }
 
     @Test
     public void testByteWithLowBitSetDecodesToOutputA() throws Exception {
-        assertThat(Output.decodeByteToSet((byte) 0b00000001), is(EnumSet.of(Output.A)));
+        assertThat(OutputId.decodeByteToSet((byte) 0b00000001), is(EnumSet.of(OutputId.A)));
     }
 
     @Test
     public void testByteWithEvenBitsSetDecodesToOutputsBDFH() throws Exception {
-        assertThat(Output.decodeByteToSet((byte) 0b10101010), is(EnumSet.of(Output.B, Output.D, Output.F, Output.H)));
+        assertThat(OutputId.decodeByteToSet((byte) 0b10101010), is(EnumSet.of(OutputId.B, OutputId.D, OutputId.F, OutputId.H)));
     }
 
     @Test
     public void testByteWithHighBitSetDecodesToOutputH() throws Exception {
-        assertThat(Output.decodeByteToSet((byte) 0b10000000), is(EnumSet.of(Output.H)));
+        assertThat(OutputId.decodeByteToSet((byte) 0b10000000), is(EnumSet.of(OutputId.H)));
     }
 
     @Test
     public void testThereAreEightOutputs() throws Exception {
-        assertThat(Output.values(), arrayWithSize(8));
+        assertThat(OutputId.values(), arrayWithSize(8));
     }
 }

--- a/src/test/java/org/chabala/brick/controllab/OutputTest.java
+++ b/src/test/java/org/chabala/brick/controllab/OutputTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2016 Greg Chabala
+ *
+ * This file is part of brick-control-lab.
+ *
+ * brick-control-lab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * brick-control-lab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with brick-control-lab.  If not, see http://www.gnu.org/licenses/.
+ */
+package org.chabala.brick.controllab;
+
+import org.junit.*;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Testing {@link Output}.
+ */
+public class OutputTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Mock
+    private ControlLab controlLab;
+
+    private OutputId outputId;
+    private Set<OutputId> outputIdSet;
+    private Output output;
+
+    private RandomEnum randomEnum = new RandomEnum();
+
+    @Before
+    public void setUp() {
+        outputId = randomEnum.get(OutputId.class);
+        outputIdSet = EnumSet.of(outputId);
+        output = new Output(controlLab, outputId);
+    }
+
+    @After
+    public void tearDown() {
+        output = null;
+        outputIdSet = null;
+        outputId = null;
+    }
+
+    @Test
+    public void testGetOutputIdSet() {
+        Set<OutputId> outputIds = output.getOutputIdSet();
+        assertThat(outputIds, contains(outputId));
+
+        thrown.expect(UnsupportedOperationException.class);
+        outputIds.add(randomEnum.get(OutputId.class));
+    }
+
+    @Test
+    public void testTurnOff() throws Exception {
+        Output newOutput = output.turnOff();
+        assertThat(newOutput, is(output));
+        verify(controlLab, times(1)).turnOutputOff(outputIdSet);
+    }
+
+    @Test
+    public void testTurnOn() throws Exception {
+        Output newOutput = output.turnOn();
+        assertThat(newOutput, is(output));
+        verify(controlLab, times(1)).turnOutputOn(outputIdSet);
+    }
+
+    @Test
+    public void testReverseDirection() throws Exception {
+        Output newOutput = output.reverseDirection();
+        assertThat(newOutput, is(output));
+        verify(controlLab, times(1)).setOutputDirection(Direction.REVERSE, outputIdSet);
+    }
+
+    @Test
+    public void testSetPowerLevel() throws Exception {
+        final PowerLevel powerLevel = randomEnum.get(PowerLevel.class);
+        Output newOutput = output.setPowerLevel(powerLevel);
+        assertThat(newOutput, is(output));
+        verify(controlLab, times(1)).setOutputPowerLevel(powerLevel, outputIdSet);
+    }
+
+    @Test
+    public void testToString() {
+        assertThat(output + "", containsString("outputIdSet=[" + outputId.name() + "]"));
+    }
+}

--- a/src/test/java/org/chabala/brick/controllab/PortChooser.java
+++ b/src/test/java/org/chabala/brick/controllab/PortChooser.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2016 Greg Chabala
+ *
+ * This file is part of brick-control-lab.
+ *
+ * brick-control-lab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * brick-control-lab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with brick-control-lab.  If not, see http://www.gnu.org/licenses/.
+ */
+package org.chabala.brick.controllab;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeThat;
+
+/**
+ * Intergration tests use this class to pick a serial port to connect to. If the
+ * default selection doesn't suit your system, you can override it with a system
+ * property: {@value OVERRIDE_TEST_PORT_PROPERTY}.
+ */
+final class PortChooser {
+    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    /** System property to override the IT serial port with a specific port identifier. */
+    public static final String OVERRIDE_TEST_PORT_PROPERTY = "brick-control-lab.overrideTestPort";
+
+    /**
+     * Picks the first available serial port based on what the serial library finds
+     * @param controlLab control lab instance for querying the serial library
+     * @return a system specific serial port identifier
+     */
+    static String choosePort(ControlLab controlLab) {
+        String overrideTestPort = System.getProperty(OVERRIDE_TEST_PORT_PROPERTY, "");
+        if (overrideTestPort.isEmpty()) {
+            List<String> availablePorts = controlLab.getAvailablePorts();
+            assumeThat("a serial port should be available", availablePorts, is(not(empty())));
+            log.debug("Available ports: {}", String.join(", ", availablePorts));
+            return availablePorts.get(0);
+        } else {
+            log.debug("{} property is defined: {}", OVERRIDE_TEST_PORT_PROPERTY, overrideTestPort);
+            return overrideTestPort;
+        }
+    }
+
+    private PortChooser() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/org/chabala/brick/controllab/RandomEnum.java
+++ b/src/test/java/org/chabala/brick/controllab/RandomEnum.java
@@ -16,21 +16,20 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with brick-control-lab.  If not, see http://www.gnu.org/licenses/.
  */
-package org.chabala.brick.controllab.sensor;
+package org.chabala.brick.controllab;
 
-import org.chabala.brick.controllab.InputId;
+import java.util.Random;
 
 /**
- * The event triggered by receiving a {@link SensorValue} from an {@link InputId}
- * that is known to be a {@link LightSensor}.
+ * Helper for choosing random enum instances for tests.
  */
-public class LightSensorEvent extends SensorEvent<LightSensor> {
-    /**
-     * Creates a LightSensorEvent from a generic {@link SensorEvent}, and wraps
-     * the {@link SensorValue} in the appropriate subclass.
-     * @param sensorEvent generic sensor event
-     */
-    public LightSensorEvent(SensorEvent<SensorValue> sensorEvent) {
-        super(sensorEvent, LightSensor::new);
+public class RandomEnum {
+
+    private Random random = new Random();
+
+    public <T extends Enum<?>> T get(Class<T> clazz) {
+        T[] enumValues = clazz.getEnumConstants();
+        int ordinal = random.nextInt(enumValues.length);
+        return enumValues[ordinal];
     }
 }

--- a/src/test/java/org/chabala/brick/controllab/StopButtonTest.java
+++ b/src/test/java/org/chabala/brick/controllab/StopButtonTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2016 Greg Chabala
+ *
+ * This file is part of brick-control-lab.
+ *
+ * brick-control-lab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * brick-control-lab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with brick-control-lab.  If not, see http://www.gnu.org/licenses/.
+ */
+package org.chabala.brick.controllab;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.chabala.brick.controllab.Protocol.STOP_DEPRESSED;
+import static org.chabala.brick.controllab.Protocol.STOP_RELEASED;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Testing the {@link StopButton}.
+ */
+public class StopButtonTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Mock
+    private InputManager inputManager;
+
+    @Mock
+    private StopButtonListener stopButtonListener;
+
+    private StopButton stopButton;
+    private ByteConsumer stopButtonCallback;
+
+    @Before
+    public void setUp() {
+        ArgumentCaptor<ByteConsumer> captor = ArgumentCaptor.forClass(ByteConsumer.class);
+        stopButton = new StopButton(inputManager);
+        verify(inputManager).setStopButtonCallback(captor.capture());
+        stopButtonCallback = captor.getValue();
+    }
+
+    @After
+    public void tearDown() {
+        stopButton = null;
+        stopButtonCallback = null;
+    }
+
+    @Test
+    public void testStopButtonIsInitiallyNotStopped() {
+        assertThat(stopButton.isStopDepressed(), is(false));
+    }
+
+    @Test
+    public void testNoEventsWhenNotStoppedAndStopNotPressed() {
+        assumeThat(stopButton.isStopDepressed(), is(false));
+        stopButton.addListener(stopButtonListener);
+        stopButtonCallback.accept(STOP_RELEASED);
+        stopButton.removeListener(stopButtonListener);
+
+        assertThat(stopButton.isStopDepressed(), is(false));
+        verify(stopButtonListener, never()).stopButtonPressed(any());
+        verify(stopButtonListener, never()).stopButtonReleased(any());
+    }
+
+    @Test
+    public void testStopPressedEventWhenNotStoppedAndStopPressed() {
+        assumeThat(stopButton.isStopDepressed(), is(false));
+        stopButton.addListener(stopButtonListener);
+        stopButtonCallback.accept(STOP_DEPRESSED);
+        stopButton.removeListener(stopButtonListener);
+
+        assertThat(stopButton.isStopDepressed(), is(true));
+        ArgumentCaptor<StopButtonEvent> captor = ArgumentCaptor.forClass(StopButtonEvent.class);
+        verify(stopButtonListener, times(1)).stopButtonPressed(captor.capture());
+        StopButtonEvent stopButtonEvent = captor.getValue();
+        assertThat(stopButtonEvent.getRawValue(), is(STOP_DEPRESSED));
+        assertThat(stopButtonEvent + "", containsString("0x10"));
+        verify(stopButtonListener, never()).stopButtonReleased(any());
+    }
+
+    @Test
+    public void testNoEventsWhenStoppedAndStopNotReleased() {
+        assumeThat(stopButton.isStopDepressed(), is(false));
+        stopButtonCallback.accept(STOP_DEPRESSED);
+        assumeThat(stopButton.isStopDepressed(), is(true));
+
+        stopButton.addListener(stopButtonListener);
+        stopButtonCallback.accept(STOP_DEPRESSED);
+        stopButton.removeListener(stopButtonListener);
+
+        assertThat(stopButton.isStopDepressed(), is(true));
+        verify(stopButtonListener, never()).stopButtonPressed(any());
+        verify(stopButtonListener, never()).stopButtonReleased(any());
+    }
+
+    @Test
+    public void testStopReleasedEventWhenStoppedAndStopReleased() {
+        assumeThat(stopButton.isStopDepressed(), is(false));
+        stopButtonCallback.accept(STOP_DEPRESSED);
+        assumeThat(stopButton.isStopDepressed(), is(true));
+
+        stopButton.addListener(stopButtonListener);
+        stopButtonCallback.accept(STOP_RELEASED);
+        stopButton.removeListener(stopButtonListener);
+
+        assertThat(stopButton.isStopDepressed(), is(false));
+        verify(stopButtonListener, never()).stopButtonPressed(any());
+        ArgumentCaptor<StopButtonEvent> captor = ArgumentCaptor.forClass(StopButtonEvent.class);
+        verify(stopButtonListener, times(1)).stopButtonReleased(captor.capture());
+        StopButtonEvent stopButtonEvent = captor.getValue();
+        assertThat(stopButtonEvent.getRawValue(), is(STOP_RELEASED));
+    }
+}

--- a/src/test/java/org/chabala/brick/controllab/sensor/LightSensorListenerTest.java
+++ b/src/test/java/org/chabala/brick/controllab/sensor/LightSensorListenerTest.java
@@ -18,7 +18,7 @@
  */
 package org.chabala.brick.controllab.sensor;
 
-import org.chabala.brick.controllab.Input;
+import org.chabala.brick.controllab.InputId;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -56,7 +56,7 @@ public class LightSensorListenerTest {
         final byte[] newValue= {};
         when(sensorValue.getAnalogValue()).thenReturn(analogValue);
         when(sensorValue.getStatusCode()).thenReturn(statusCode);
-        SensorEvent<SensorValue> sensorEvent = new SensorEvent<>(Input.I1, oldValue, newValue, sensorValue);
+        SensorEvent<SensorValue> sensorEvent = new SensorEvent<>(InputId.I1, oldValue, newValue, sensorValue);
         LightSensorListener listener = event -> {
             assertThat(event.getValue().getAnalogValue(), is(analogValue));
             assertThat(event.getValue().getStatusCode(), is(statusCode));

--- a/src/test/java/org/chabala/brick/controllab/sensor/TouchSensorListenerTest.java
+++ b/src/test/java/org/chabala/brick/controllab/sensor/TouchSensorListenerTest.java
@@ -18,7 +18,7 @@
  */
 package org.chabala.brick.controllab.sensor;
 
-import org.chabala.brick.controllab.Input;
+import org.chabala.brick.controllab.InputId;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -56,7 +56,7 @@ public class TouchSensorListenerTest {
         final byte[] newValue= {};
         when(sensorValue.getAnalogValue()).thenReturn(analogValue);
         when(sensorValue.getStatusCode()).thenReturn(statusCode);
-        SensorEvent<SensorValue> sensorEvent = new SensorEvent<>(Input.I1, oldValue, newValue, sensorValue);
+        SensorEvent<SensorValue> sensorEvent = new SensorEvent<>(InputId.I1, oldValue, newValue, sensorValue);
         TouchSensorListener listener = event -> {
             assertThat(event.getValue().getAnalogValue(), is(analogValue));
             assertThat(event.getValue().getStatusCode(), is(statusCode));


### PR DESCRIPTION
The main ControlLab interface was getting crowded with methods for adding event listeners. Now all the objects one might bind a listener to are real independent objects, and those objects have a fluent API for method chaining.