### PR TITLE
Update Apache BCEL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.chabala.brick</groupId>
     <artifactId>brick-control-lab</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.2.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
     <description>Library for controlling the LEGO® control lab interface.</description>
@@ -103,7 +103,7 @@
                         <dependency>
                             <groupId>org.apache.bcel</groupId>
                             <artifactId>bcel</artifactId>
-                            <version>6.4.1</version>
+                            <version>6.7.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
@dependabot has been complaining about https://nvd.nist.gov/vuln/detail/CVE-2022-42920 even though BCEL is only used by a Maven reporting plugin.