### PR TITLE
Allow triggering build manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request: # all pull requests
+  workflow_dispatch: # allow triggering manually
 
 jobs:
   build:


### PR DESCRIPTION
GitHub Actions retains logs for 90 days. After that, only 

> The logs for this run have expired and are no longer available.

 is shown.

If one wants to review what a passing build looks like, and all logs have expired, it would be nice to be able to kick off a new build without needing to commit changes. `workflow_dispatch` will allow that manual kickoff button to appear in the GitHub Actions UI.