### PR TITLE
Configure for reproducible builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <source.version>1.8</source.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.build.outputTimestamp>2023-08-23T00:00:00Z</project.build.outputTimestamp>
         <ghUser>chabala</ghUser>
         <ghProjectUrl>https://github.com/${ghUser}/${project.artifactId}</ghProjectUrl>
         <ghPagesUrl>https://${ghUser}.github.io/${project.artifactId}/</ghPagesUrl>
@@ -70,7 +71,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.2.0</version>
                     <configuration>
                         <docfilessubdirs>true</docfilessubdirs>
                         <links>
@@ -87,6 +88,7 @@
     </script>]]>
                         </header>
                         <additionalJOptions>--allow-script-in-comments</additionalJOptions>
+                        <notimestamp>true</notimestamp>
                     </configuration>
                     <dependencies>
                         <dependency>
@@ -113,7 +115,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-linkcheck-plugin</artifactId>
@@ -193,7 +195,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>


### PR DESCRIPTION
Now that [reproducible builds](https://maven.apache.org/guides/mini/guide-reproducible-builds.html) are mature, prepare to release 0.2.1 as a reproducible version of 0.2.0.

There have been [no code changes since 0.2.0](https://github.com/chabala/brick-control-lab/compare/0.2.0...42658fc2ab98d37cbe714894cef7ce2c4d2b25e3), only build tooling configuration and documentation.