### PR TITLE
Replace Travis CI (.org) with GitHub Actions, in pom.xml and README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ instructions and additional documentation.
 Licensed under [GNU Lesser General Public License 3.0](https://www.gnu.org/licenses/lgpl-3.0.en.html)
 
 [1]: http://www.peeron.com/inv/sets/9751-1
-[2]: https://travis-ci.org/chabala/brick-control-lab.svg?branch=master
-[3]: https://travis-ci.org/chabala/brick-control-lab
+[2]: https://github.com/chabala/brick-control-lab/actions/workflows/build.yml/badge.svg?branch=master
+[3]: https://github.com/chabala/brick-control-lab/actions/workflows/build.yml
 [4]: https://img.shields.io/badge/license-GNU_LGPL_3.0-brightgreen.svg
-[5]: https://api.codacy.com/project/badge/Grade/f05f0d18f49a48659b1066884a7fef68
-[6]: https://www.codacy.com/app/chabala/brick-control-lab
+[5]: https://app.codacy.com/project/badge/Grade/1635550c03fb4874889f145d3d9bd237?branch=master
+[6]: https://app.codacy.com/gh/chabala/brick-control-lab/dashboard
 [7]: https://coveralls.io/repos/github/chabala/brick-control-lab/badge.svg?branch=master
 [8]: https://coveralls.io/github/chabala/brick-control-lab?branch=master
 [9]: https://www.bricklink.com/SL/9751-1.jpg

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>3.1.2</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.bcel</groupId>
@@ -145,7 +145,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.5</version>
+                    <version>0.8.10</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -282,22 +282,26 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>3.0</version>
+                <version>4.2</version>
                 <configuration>
-                    <header>src/main/config/copyright_template.txt</header>
                     <properties>
                         <owner>Greg Chabala</owner>
                     </properties>
-                    <useDefaultExcludes>true</useDefaultExcludes>
-                    <excludes>
-                        <exclude>**/pom*.xml</exclude>
-                        <exclude>**/COPYING*</exclude>
-                        <exclude>src/main/config/**</exclude>
-                        <exclude>**/resources/**</exclude>
-                        <exclude>.github/**</exclude>
-                        <exclude>.mvn/jvm.config</exclude>
-                        <exclude>.shelf/**</exclude>
-                    </excludes>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>src/main/config/copyright_template.txt</header>
+                            <useDefaultExcludes>true</useDefaultExcludes>
+                            <excludes>
+                                <exclude>**/pom*.xml</exclude>
+                                <exclude>**/COPYING*</exclude>
+                                <exclude>src/main/config/**</exclude>
+                                <exclude>**/resources/**</exclude>
+                                <exclude>.github/**</exclude>
+                                <exclude>.mvn/jvm.config</exclude>
+                                <exclude>.shelf/**</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
                     <mapping>
                         <java>SLASHSTAR_STYLE</java>
                     </mapping>
@@ -547,7 +551,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.0.1</version>
+            <version>4.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -579,13 +579,13 @@
         <url>${ghProjectUrl}/issues</url>
     </issueManagement>
     <ciManagement>
-        <system>travis</system>
-        <url>https://travis-ci.org/${ghUser}/${project.artifactId}</url>
+        <system>GitHub</system>
+        <url>${ghProjectUrl}/actions</url>
     </ciManagement>
     <licenses>
         <license>
             <name>GNU Lesser General Public License 3.0</name>
-            <url>http://www.gnu.org/licenses/lgpl-3.0.txt</url>
+            <url>https://www.gnu.org/licenses/lgpl-3.0.txt</url>
             <distribution>repo</distribution>
         </license>
     </licenses>

--- a/src/site/markdown/building.md
+++ b/src/site/markdown/building.md
@@ -14,7 +14,7 @@ pre-built jars. Building from source is only necessary for developing brick-cont
 $ git clone git@github.com:chabala/brick-control-lab.git
 ```
 
-See [Source Code Management](source-repository.html) for more details regarding this.
+See [Source Code Management](scm.html) for more details regarding this.
 
 ### Building
 Run ```mvn clean verify``` to clean, compile, test, and produce the artifact.

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -53,7 +53,7 @@ JRE modifications.
 ### Licensing
 Licensed under [GNU Lesser General Public License 3.0](https://www.gnu.org/licenses/lgpl-3.0.en.html)
 
-See also: [Licenses](license.html)
+See also: [Licenses](licenses.html)
 
 ---
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -56,17 +56,17 @@
         </menu>
         <menu name="Project Documentation">
             <item name="Project Information" href="project-info.html" collapse="true">
-                <item name="Summary" href="project-summary.html"/>
+                <item name="Summary" href="summary.html"/>
                 <item name="Dependency Information" href="dependency-info.html"/>
-                <item name="Distribution Management" href="distribution-management.html"/>
                 <item name="Dependencies" href="dependencies.html"/>
-                <item name="CI Management" href="integration.html"/>
-                <item name="Issue Management" href="issue-tracking.html"/>
-                <item name="Licenses" href="license.html"/>
+                <item name="CI Management" href="ci-management.html"/>
+                <item name="Issue Management" href="issue-management.html"/>
+                <item name="Licenses" href="licenses.html"/>
                 <item name="Plugin Management" href="plugin-management.html"/>
                 <item name="Plugins" href="plugins.html"/>
-                <item name="Team" href="team-list.html"/>
-                <item name="Source Code Management" href="source-repository.html"/>
+                <item name="Team" href="team.html"/>
+                <item name="Source Code Management" href="scm.html"/>
+                <item name="Distribution Management" href="distribution-management.html"/>
             </item>
             <item name="Project Reports" href="project-reports.html" collapse="true">
                 <item name="GitHub Report" href="github-report.html"/>


### PR DESCRIPTION

 * also fix Codacy badge ಠ_ಠ
 
I considered editing the CI report to link to historic Travis CI builds, but they've lost them, so there's no point in mentioning it.