### PR TITLE
Use clean URLs for the generated Maven site

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,11 +92,11 @@ jobs:
           name: build
           path: .
 
-      - name: 'Set up Java 11'
+      - name: 'Set up Java 17'
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
           cache: 'maven'
 
       - name: 'Cache SonarCloud packages'

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,11 @@
                     <artifactId>sonar-maven-plugin</artifactId>
                     <version>3.7.0.1746</version>
                 </plugin>
+                <plugin>
+                    <groupId>com.github.genthaler</groupId>
+                    <artifactId>beanshell-maven-plugin</artifactId>
+                    <version>1.4</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -398,6 +403,54 @@
                             <target>
                                 <delete file="${project.basedir}/velocity.log" />
                             </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.genthaler</groupId>
+                <artifactId>beanshell-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-redirect-pages</id>
+                        <phase>pre-site</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <quiet>true</quiet>
+                            <script><![CDATA[
+                            // Generate redirect pages for historic site URLs (MPIR-323)
+                            String contents(String target) {
+                                String url = project.url + target;
+                                String template = "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" " +
+                                        "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n" +
+                                        "<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\n" +
+                                        "<head>\n" +
+                                        "    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\n" +
+                                        "    <link rel=\"canonical\" href=\"" + url + "\" />\n" +
+                                        "    <meta http-equiv=\"refresh\" content=\"0;url=" + target + "\" />\n" +
+                                        "</head>\n<body>\n<h1>\n" +
+                                        "    This page has been moved to <a href=\"" + target + "\">" + url + "</a>\n" +
+                                        "    <script type='text/javascript'> window.location.replace(\"" + url + "\"); </script>\n" +
+                                        "</h1>\n</body>\n</html>\n";
+                                return template;
+                            }
+                            File site = new File(project.reporting.outputDirectory);
+                            site.mkdirs();
+                            String[][] filenameArray = new String[][] {
+                                    {"integration.html", "ci-management.html"},
+                                    {"issue-tracking.html", "issue-management.html"},
+                                    {"license.html", "licenses.html"},
+                                    {"project-summary.html", "summary.html"},
+                                    {"source-repository.html", "scm.html"},
+                                    {"team-list.html", "team.html"}};
+                            for (int i=0; i<filenameArray.length; i++) {
+                                File file = new File(site, filenameArray[i][0]);
+                                org.codehaus.plexus.util.FileUtils.fileWrite(file, "UTF-8", contents(filenameArray[i][1]));
+                            }
+                            ]]>
+                            </script>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,13 @@
                     <groupId>com.github.genthaler</groupId>
                     <artifactId>beanshell-maven-plugin</artifactId>
                     <version>1.4</version>
+                    <dependencies>
+                        <dependency><!-- used by late-site-add-canonical-urls -->
+                            <groupId>org.jsoup</groupId>
+                            <artifactId>jsoup</artifactId>
+                            <version>1.17.2</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -449,6 +456,87 @@
                                 File file = new File(site, filenameArray[i][0]);
                                 org.codehaus.plexus.util.FileUtils.fileWrite(file, "UTF-8", contents(filenameArray[i][1]));
                             }
+                            ]]>
+                            </script>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>late-site-add-canonical-urls</id>
+                        <phase>site</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <quiet>true</quiet>
+                            <script><![CDATA[
+// Add canonical URLs to any site HTML pages that are missing them
+String buildCanonicalUrl(String absoluteFilePath, String baseDirectory, String baseUrl) {
+    String urlPath = (
+        org.codehaus.plexus.util.FileUtils.basename(absoluteFilePath).equalsIgnoreCase("index.")
+            ? org.codehaus.plexus.util.FileUtils.dirname(absoluteFilePath) + File.separator
+            : absoluteFilePath
+        ).substring(baseDirectory.length());
+    return baseUrl + (File.separator.equals("/") ? urlPath : urlPath.replace(File.separator, "/"));
+}
+void insert(String filename, long offset, String content) throws IOException {
+    File tempFile = File.createTempFile(org.codehaus.plexus.util.FileUtils.filename(filename), null);
+    try {
+        RandomAccessFile r = new RandomAccessFile(new File(filename), "rw");
+        try {
+            RandomAccessFile rtemp = new RandomAccessFile(tempFile, "rw");
+            try {
+                final long fileSize = r.length();
+                java.nio.channels.FileChannel sourceChannel = r.getChannel();
+                try {
+                    java.nio.channels.FileChannel targetChannel = rtemp.getChannel();
+                    try {
+                        //move origin file contents from offset to end-of-file to temp file
+                        sourceChannel.transferTo(offset, (fileSize - offset), targetChannel);
+                        //clear origin file after offset
+                        sourceChannel.truncate(offset);
+                        r.seek(offset);        //move to new end-of-file
+                        r.writeBytes(content); //write new content
+                        long newOffset = r.getFilePointer(); //obtain offset for new end-of-file
+                        targetChannel.position(0L); //set cursor in temp file to beginning for read
+                        //move saved content from temp file back to end of origin file
+                        sourceChannel.transferFrom(targetChannel, newOffset, (fileSize - offset));
+                    } finally {
+                        targetChannel.close();
+                    }
+                } finally {
+                    sourceChannel.close();
+                }
+            } finally {
+                rtemp.close();
+            }
+        } finally {
+            r.close();
+        }
+    } finally {
+        org.codehaus.plexus.util.FileUtils.forceDelete(tempFile);
+    }
+}
+int countCanonicalLinks(File htmlFile, String projectUrl) throws IOException {
+    //jsoup object scope
+    org.jsoup.nodes.Document document = org.jsoup.Jsoup.parse(htmlFile, "UTF-8", projectUrl);
+    return document.head().selectXpath("//link[@rel='canonical']").size();
+}
+void ensureCanonicalLink(String absoluteFilePath, String outputDirectory, String projectUrl) throws IOException {
+    if (countCanonicalLinks(new File(absoluteFilePath), projectUrl) == 0) {
+        //build canonical link tag
+        String canonicalLinkTag = "<link rel=\"canonical\" href=\"" +
+            buildCanonicalUrl(absoluteFilePath, outputDirectory, projectUrl.substring(0, projectUrl.length() - 1)) + "\" />\n";
+        //find </head>
+        int offset = org.codehaus.plexus.util.FileUtils.fileRead(absoluteFilePath, "UTF-8").indexOf("</head>");
+        //insert link tag and linebreak
+        insert(absoluteFilePath, offset, canonicalLinkTag);
+    }
+}
+files = org.codehaus.plexus.util.FileUtils.getFilesFromExtension(
+    project.reporting.outputDirectory, new String[] { "htm", "html" });
+for (int i=0; i<files.length; i++) {
+    ensureCanonicalLink(files[i], project.reporting.outputDirectory, project.url);
+}
                             ]]>
                             </script>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,7 @@
             <plugin>
                 <groupId>org.simplify4u.plugins</groupId>
                 <artifactId>sitemapxml-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.2.0</version>
                 <configuration>
                     <maxDepth>8</maxDepth>
                 </configuration>


### PR DESCRIPTION
This PR automates for future builds various changes to the published Maven site that were made manually, in 9c9bd0a61826dae2acb19ebb465e619d220ca51f & b001cc398c7633bbda4960c90afa61ca4800d3c8 , to improve SEO based on the recommendations of Google Search Console, namely:

- using clean URLs in the sitemap (in this case, preferring index page URLs to end with `/`, rather than `/index.html`)
- [canonical URL link](https://en.wikipedia.org/wiki/Canonical_link_element) tags on every page (again respecting the clean URL style)
- redirect pages for pages that relocated due to [MPIR-323](https://issues.apache.org/jira/browse/MPIR-323)

It also makes for an interesting example of using [BeanShell](https://beanshell.github.io/) in the `beanshell-maven-plugin` to perform custom, free form tasks, and how not fun it is to be stuck in pre-Java-5 language syntax, without generics, varargs, or try-with-resources.