### PR TITLE
Update various GitHub Actions for security updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: 'Set up Java 8'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 8
@@ -27,7 +27,7 @@ jobs:
           mvn -V --batch-mode verify jacoco:report
 
       - name: 'Upload directory to pass to next job'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: .
@@ -49,14 +49,19 @@ jobs:
     if: needs.coveralls-pre-check.outputs.HAVE_REPO_TOKEN == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: 'Restore directory from build'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
           path: .
 
       - name: 'Set up Java 8'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 8
@@ -86,21 +91,26 @@ jobs:
     if: needs.sonar-pre-check.outputs.HAVE_SONAR_TOKEN == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: 'Restore directory from build'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
           path: .
 
       - name: 'Set up Java 17'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 17
           cache: 'maven'
 
       - name: 'Cache SonarCloud packages'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar


### PR DESCRIPTION
@dependabot opened issue #27 on Sept 3rd to update https://github.com/actions/download-artifact from v3 to v4.1.7.

But curiously, it didn't mention updating actions/upload-artifact@v3, which is also based on [actions/artifact](https://github.com/actions/toolkit/tree/main/packages/artifact).

It also didn't mention the reason for the update: https://github.com/advisories/GHSA-cxww-7g56-2vh6

[actions/download-artifact@4.1.7](https://github.com/actions/download-artifact/releases/tag/v4.1.7) contains actions/artifact@2.1.7 which resolves the path traversal issue.

It also fixes a more serious issue, leaking tokens in hidden files in artifacts:

* https://unit42.paloaltonetworks.com/github-repo-artifacts-leak-tokens/ (Published:13 August 2024)
* https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/

Other reasons for moving to v4:

* https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/
* https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/